### PR TITLE
Fixup DateTime conversion of DateTimes with msec

### DIFF
--- a/source/ddbc/drivers/pgsqlddbc.d
+++ b/source/ddbc/drivers/pgsqlddbc.d
@@ -32,6 +32,7 @@ version(USE_PGSQL) {
     import std.stdio;
     import std.string;
     import std.variant;
+    import std.array;
     import core.sync.mutex;
     
     import ddbc.common;
@@ -394,7 +395,7 @@ version(USE_PGSQL) {
                                     v[col] = byteaToUbytes(s);
                                     break;
                                 case TIMESTAMPOID:
-                                    v[col] = DateTime.fromISOExtString( s.translate( [ ' ': 'T' ] ) );
+                                    v[col] = DateTime.fromISOExtString( s.translate( [ ' ': 'T' ] ).split( '.' ).front() );
                                     break;
                                 default:
                                     throw new SQLException("Unsupported column type " ~ to!string(t));


### PR DESCRIPTION
PostgreSQL does not like the DateTime.fromISOExtString format. Discarding the dot-msec part fixes this.