### PR TITLE
Fix "static if" clauses in pod.d per "Programming in D" pg 429 note:

### DIFF
--- a/source/ddbc/pods.d
+++ b/source/ddbc/pods.d
@@ -227,7 +227,7 @@ template isSupportedSimpleType(T, string m) {
             enum bool isSupportedSimpleType = true;
         } else static if (is(ReturnType!(ti) == ubyte[])) {
             enum bool isSupportedSimpleType = true;
-        } else {
+        } else static if (true) {
             enum bool isSupportedSimpleType = false;
         }
     } else static if (is(ti == bool)) {
@@ -292,7 +292,7 @@ template isSupportedSimpleType(T, string m) {
         enum bool isSupportedSimpleType = true;
     } else static if (is(ti == ubyte[])) {
         enum bool isSupportedSimpleType = true;
-    } else {
+    } else static if (true) {
         enum bool isSupportedSimpleType = false;
     }
 }
@@ -302,67 +302,67 @@ PropertyMemberType getPropertyType(ti)() {
     //alias typeof(T) ti;
 	static if (is(ti == bool)) {
 		return PropertyMemberType.BOOL_TYPE;
-    } else if (is(ti == byte)) {
+    } else static if (is(ti == byte)) {
         return PropertyMemberType.BYTE_TYPE;
-    } else if (is(ti == short)) {
+    } else static if (is(ti == short)) {
         return PropertyMemberType.SHORT_TYPE;
-    } else if (is(ti == int)) {
+    } else static if (is(ti == int)) {
         return PropertyMemberType.INT_TYPE;
-    } else if (is(ti == long)) {
+    } else static if (is(ti == long)) {
         return PropertyMemberType.LONG_TYPE;
-    } else if (is(ti == ubyte)) {
+    } else static if (is(ti == ubyte)) {
         return PropertyMemberType.UBYTE_TYPE;
-    } else if (is(ti == ushort)) {
+    } else static if (is(ti == ushort)) {
         return PropertyMemberType.USHORT_TYPE;
-    } else if (is(ti == uint)) {
+    } else static if (is(ti == uint)) {
         return PropertyMemberType.UINT_TYPE;
-    } else if (is(ti == ulong)) {
+    } else static if (is(ti == ulong)) {
         return PropertyMemberType.ULONG_TYPE;
-    } else if (is(ti == float)) {
+    } else static if (is(ti == float)) {
         return PropertyMemberType.FLOAT_TYPE;
-    } else if (is(ti == double)) {
+    } else static if (is(ti == double)) {
         return PropertyMemberType.DOUBLE_TYPE;
-    } else if (is(ti == Nullable!byte)) {
+    } else static if (is(ti == Nullable!byte)) {
         return PropertyMemberType.NULLABLE_BYTE_TYPE;
-    } else if (is(ti == Nullable!short)) {
+    } else static if (is(ti == Nullable!short)) {
         return PropertyMemberType.NULLABLE_SHORT_TYPE;
-    } else if (is(ti == Nullable!int)) {
+    } else static if (is(ti == Nullable!int)) {
         return PropertyMemberType.NULLABLE_INT_TYPE;
-    } else if (is(ti == Nullable!long)) {
+    } else static if (is(ti == Nullable!long)) {
         return PropertyMemberType.NULLABLE_LONG_TYPE;
-    } else if (is(ti == Nullable!ubyte)) {
+    } else static if (is(ti == Nullable!ubyte)) {
         return PropertyMemberType.NULLABLE_UBYTE_TYPE;
-    } else if (is(ti == Nullable!ushort)) {
+    } else static if (is(ti == Nullable!ushort)) {
         return PropertyMemberType.NULLABLE_USHORT_TYPE;
-    } else if (is(ti == Nullable!uint)) {
+    } else static if (is(ti == Nullable!uint)) {
         return PropertyMemberType.NULLABLE_UINT_TYPE;
-    } else if (is(ti == Nullable!ulong)) {
+    } else static if (is(ti == Nullable!ulong)) {
         return PropertyMemberType.NULLABLE_ULONG_TYPE;
-    } else if (is(ti == Nullable!float)) {
+    } else static if (is(ti == Nullable!float)) {
         return PropertyMemberType.NULLABLE_FLOAT_TYPE;
-    } else if (is(ti == Nullable!double)) {
+    } else static if (is(ti == Nullable!double)) {
         return PropertyMemberType.NULLABLE_DOUBLE_TYPE;
-    } else if (is(ti == string)) {
+    } else static if (is(ti == string)) {
         return PropertyMemberType.STRING_TYPE;
-    } else if (is(ti == String)) {
+    } else static if (is(ti == String)) {
         return PropertyMemberType.NULLABLE_STRING_TYPE;
-    } else if (is(ti == DateTime)) {
+    } else static if (is(ti == DateTime)) {
         return PropertyMemberType.DATETIME_TYPE;
-    } else if (is(ti == Date)) {
+    } else static if (is(ti == Date)) {
         return PropertyMemberType.DATE_TYPE;
-    } else if (is(ti == TimeOfDay)) {
+    } else static if (is(ti == TimeOfDay)) {
         return PropertyMemberType.TIME_TYPE;
-    } else if (is(ti == Nullable!DateTime)) {
+    } else static if (is(ti == Nullable!DateTime)) {
         return PropertyMemberType.NULLABLE_DATETIME_TYPE;
-    } else if (is(ti == Nullable!Date)) {
+    } else static if (is(ti == Nullable!Date)) {
         return PropertyMemberType.NULLABLE_DATE_TYPE;
-    } else if (is(ti == Nullable!TimeOfDay)) {
+    } else static if (is(ti == Nullable!TimeOfDay)) {
         return PropertyMemberType.NULLABLE_TIME_TYPE;
-    } else if (is(ti == byte[])) {
+    } else static if (is(ti == byte[])) {
         return PropertyMemberType.BYTE_ARRAY_TYPE;
-    } else if (is(ti == ubyte[])) {
+    } else static if (is(ti == ubyte[])) {
         return PropertyMemberType.UBYTE_ARRAY_TYPE;
-    } else {
+    } else static if (true) {
         assert (false, "has unsupported type " ~ ti.stringof);
     }
 }
@@ -371,67 +371,67 @@ PropertyMemberType getPropertyMemberType(T, string m)() {
     alias typeof(__traits(getMember, T, m)) ti;
     static if (is(ti == bool)) {
         return PropertyMemberType.BOOL_TYPE;
-    } else if (is(ti == byte)) {
+    } else static if (is(ti == byte)) {
         return PropertyMemberType.BYTE_TYPE;
-    } else if (is(ti == short)) {
+    } else static if (is(ti == short)) {
         return PropertyMemberType.SHORT_TYPE;
-    } else if (is(ti == int)) {
+    } else static if (is(ti == int)) {
         return PropertyMemberType.INT_TYPE;
-    } else if (is(ti == long)) {
+    } else static if (is(ti == long)) {
         return PropertyMemberType.LONG_TYPE;
-    } else if (is(ti == ubyte)) {
+    } else static if (is(ti == ubyte)) {
         return PropertyMemberType.UBYTE_TYPE;
-    } else if (is(ti == ushort)) {
+    } else static if (is(ti == ushort)) {
         return PropertyMemberType.USHORT_TYPE;
-    } else if (is(ti == uint)) {
+    } else static if (is(ti == uint)) {
         return PropertyMemberType.UINT_TYPE;
-    } else if (is(ti == ulong)) {
+    } else static if (is(ti == ulong)) {
         return PropertyMemberType.ULONG_TYPE;
-    } else if (is(ti == float)) {
+    } else static if (is(ti == float)) {
         return PropertyMemberType.FLOAT_TYPE;
-    } else if (is(ti == double)) {
+    } else static if (is(ti == double)) {
         return PropertyMemberType.DOUBLE_TYPE;
-    } else if (is(ti == Nullable!byte)) {
+    } else static if (is(ti == Nullable!byte)) {
         return PropertyMemberType.NULLABLE_BYTE_TYPE;
-    } else if (is(ti == Nullable!short)) {
+    } else static if (is(ti == Nullable!short)) {
         return PropertyMemberType.NULLABLE_SHORT_TYPE;
-    } else if (is(ti == Nullable!int)) {
+    } else static if (is(ti == Nullable!int)) {
         return PropertyMemberType.NULLABLE_INT_TYPE;
-    } else if (is(ti == Nullable!long)) {
+    } else static if (is(ti == Nullable!long)) {
         return PropertyMemberType.NULLABLE_LONG_TYPE;
-    } else if (is(ti == Nullable!ubyte)) {
+    } else static if (is(ti == Nullable!ubyte)) {
         return PropertyMemberType.NULLABLE_UBYTE_TYPE;
-    } else if (is(ti == Nullable!ushort)) {
+    } else static if (is(ti == Nullable!ushort)) {
         return PropertyMemberType.NULLABLE_USHORT_TYPE;
-    } else if (is(ti == Nullable!uint)) {
+    } else static if (is(ti == Nullable!uint)) {
         return PropertyMemberType.NULLABLE_UINT_TYPE;
-    } else if (is(ti == Nullable!ulong)) {
+    } else static if (is(ti == Nullable!ulong)) {
         return PropertyMemberType.NULLABLE_ULONG_TYPE;
-    } else if (is(ti == Nullable!float)) {
+    } else static if (is(ti == Nullable!float)) {
         return PropertyMemberType.NULLABLE_FLOAT_TYPE;
-    } else if (is(ti == Nullable!double)) {
+    } else static if (is(ti == Nullable!double)) {
         return PropertyMemberType.NULLABLE_DOUBLE_TYPE;
-    } else if (is(ti == string)) {
+    } else static if (is(ti == string)) {
         return PropertyMemberType.STRING_TYPE;
-    } else if (is(ti == String)) {
+    } else static if (is(ti == String)) {
         return PropertyMemberType.NULLABLE_STRING_TYPE;
-    } else if (is(ti == DateTime)) {
+    } else static if (is(ti == DateTime)) {
         return PropertyMemberType.DATETIME_TYPE;
-    } else if (is(ti == Date)) {
+    } else static if (is(ti == Date)) {
         return PropertyMemberType.DATE_TYPE;
-    } else if (is(ti == TimeOfDay)) {
+    } else static if (is(ti == TimeOfDay)) {
         return PropertyMemberType.TIME_TYPE;
-    } else if (is(ti == Nullable!DateTime)) {
+    } else static if (is(ti == Nullable!DateTime)) {
         return PropertyMemberType.NULLABLE_DATETIME_TYPE;
-    } else if (is(ti == Nullable!Date)) {
+    } else static if (is(ti == Nullable!Date)) {
         return PropertyMemberType.NULLABLE_DATE_TYPE;
-    } else if (is(ti == Nullable!TimeOfDay)) {
+    } else static if (is(ti == Nullable!TimeOfDay)) {
         return PropertyMemberType.NULLABLE_TIME_TYPE;
-    } else if (is(ti == byte[])) {
+    } else static if (is(ti == byte[])) {
         return PropertyMemberType.BYTE_ARRAY_TYPE;
-    } else if (is(ti == ubyte[])) {
+    } else static if (is(ti == ubyte[])) {
         return PropertyMemberType.UBYTE_ARRAY_TYPE;
-    } else {
+    } else static if (true) {
         assert (false, "Member " ~ m ~ " of class " ~ T.stringof ~ " has unsupported type " ~ ti.stringof);
     }
 }
@@ -900,7 +900,7 @@ template isSupportedSimpleTypeRef(M) {
         enum bool isSupportedSimpleType = true;
     } else static if (is(ti == ubyte[])) {
         enum bool isSupportedSimpleType = true;
-    } else {
+    } else static if (true) {
         enum bool isSupportedSimpleType = false;
     }
 }


### PR DESCRIPTION
   Note that one must write else static if when chaining static if clauses. Otherwise,
   writing else if would result in inserting that if conditional into the code, which would
   naturally be executed at run time.

ps. I kept having problems with quill-d ability to use ubyte[].  Still working on it but noticed it was at the end of your static if's.  Don't know if this helps yet.