### PR TITLE
Fix the OSX travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,22 @@ language: d
 sudo: required
 dist: trusty
 
+# start most recent dmd and ldc first, then pre-release & older versions
 d:
   - dmd
-  - dmd-2.069.2
   - ldc
+  - dmd-2.071.2-b6
+  - dmd-2.070.0
+  - dmd-2.069.2
+  - ldc-1.1.0-beta2
+  - ldc-0.17.0
   - gdc
 
 # make sure our Mac build uses OS X 10.11 rather than default (10.9) so we have more recent sqlite
 osx_image: xcode7.3
 
 before_install:
- - "if [ ${TRAVIS_OS_NAME} = 'osx' ]; then brew install sqlite && brew link --force sqlite; fi"
+ - "if [ ${TRAVIS_OS_NAME} = 'osx' ]; then brew update && brew install sqlite && brew link --force sqlite; fi"
 
 os:
  - linux
@@ -28,7 +33,13 @@ addons:
   apt:
     packages: [ libsqlite3-dev ]
 
-# GDC lags behind DMD
+# GDC lags behind DMD. There's a problem linking sqlite on the Travis OSX with LDC builds
 matrix:
   allow_failures:
+    - os: osx
+      d: ldc
+    - os: osx
+      d: ldc-1.1.0-beta2
+    - os: osx
+      d: ldc-0.17.0
     - d: gdc

--- a/dub.json
+++ b/dub.json
@@ -6,6 +6,7 @@
     "license": "Boost Software License (BSL 1.0)",
     "targetPath": "lib",
     "targetType": "staticLibrary",
+    "systemDependencies": "Depending on configuration: PostgreSQL and/or SQLite v3",
     "configurations": [
         {
             "name": "full",
@@ -22,7 +23,7 @@
             "name": "MySQL",
             "versions": ["USE_MYSQL"],
             "dependencies": {
-                "mysql-native": ">=0.0.12"
+                "mysql-native": ">=0.1.6"
             }
         },
         {
@@ -44,6 +45,7 @@
         {
             "name": "test",
             "sourcePaths" : ["test/ddbctest"],
+            "mainSourceFile": "test/ddbctest/main.d",
             "targetName": "ddbc-tests",
             "targetPath": "test",
             "targetType": "executable",


### PR DESCRIPTION
I've not found a way get around travis OSX & LDC builds failing when linking with sqlite. So for now they are in the allow failures block. 