### PR TITLE
Fixed referenced code (missing imports)

### DIFF
--- a/source/ddbc/drivers/mysqlddbc.d
+++ b/source/ddbc/drivers/mysqlddbc.d
@@ -38,6 +38,9 @@ import ddbc.core;
 version(USE_MYSQL) {
 
 import mysql.connection;
+import mysql.commands;
+import mysql.protocol.packets;
+import mysql.protocol.constants;
 
 version(unittest) {
     /*


### PR DESCRIPTION
I was unable to compile my project (depending on ddbc) after dub upgrade (from 0.2.25) unless I have added these three imports. The same change was necessary in 0.2.35 branch.