### PR TITLE
Fixed missing imports, the reaseon is that mysql-native upgrade to v1.0.0

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -12,8 +12,8 @@
             "name": "full",
             "versions": ["USE_MYSQL", "USE_SQLITE", "USE_PGSQL"],
             "dependencies": {
-                "mysql-native": ">=0.1.6",
-                "derelict-pq": "~>2.0.2"
+                "mysql-native": ">=1.0.0",
+                "derelict-pq": "~>2.0.3"
             },
             "libs-posix": ["sqlite3"],
             "libs-windows": ["sqlite3"],
@@ -26,7 +26,7 @@
             "name": "MySQL",
             "versions": ["USE_MYSQL"],
             "dependencies": {
-                "mysql-native": ">=0.1.6"
+                "mysql-native": ">=1.0.0"
             }
         },
         {
@@ -45,7 +45,7 @@
             "copyFiles-windows-x86": [ "libs/win32/libpq.dll"],
             "copyFiles-windows-x86_64": [ "libs/win64/libpq.dll"],
             "dependencies": {
-                "derelict-pq": "~>2.0.2"
+                "derelict-pq": "~>2.0.3"
             }
         },
         {

--- a/source/ddbc/drivers/mysqlddbc.d
+++ b/source/ddbc/drivers/mysqlddbc.d
@@ -38,6 +38,9 @@ import ddbc.core;
 version(USE_MYSQL) {
 
 import mysql.connection;
+import mysql.commands;
+import mysql.protocol.packets;
+import mysql.protocol.constants;
 
 version(unittest) {
     /*


### PR DESCRIPTION
the reaseon is that mysql-native upgrade to v1.0.0; in this version, package.d file is not public import mysql.protocol.packets;

fixed.