### PR TITLE
fix compatibility issue with more recent mysql-native

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ matrix:
       before_script: mysql -e 'CREATE DATABASE ddbctest;'
       script:
         - dub build --config=full
-        - cd example && dub build && ./ddbctest --connection=mysql:127.0.0.1 --database=test --user=ddbctest
+        - cd example && dub build && ./ddbctest --connection=mysql:127.0.0.1 --database=ddbctest --user=root
     - env: NAME="PostgreSQL Integration Test"
       d: dmd
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,22 +3,21 @@ language: d
 # See: https://docs.travis-ci.com/user/trusty-ci-environment/#Routing-to-Trusty
 sudo: required
 dist: trusty
+group: edge
 
 # start most recent dmd and ldc first, then older versions. (don't bother with pre-release')
 # For available compilers see: https://semitwist.com/travis-d-compilers
 d:
   - ldc
-  - dmd
-  - dmd-2.074.0
+  - dmd-2.075.1
+  - dmd-2.074.1
   - dmd-2.073.2
-  - dmd-2.072.2
-  - dmd-2.071.2
-  - ldc-1.2.0 # eq to dmd v2.072.2
-  - ldc-1.1.1 # eq to dmd v2.071.2
+  - ldc-1.4.0 # eq to dmd v2.074.1
+  - ldc-1.3.0 # eq to dmd v2.073.2
   - gdc
 
-# make sure our Mac build uses latest OS X. See: https://docs.travis-ci.com/user/osx-ci-environment/#OS-X-Version
-osx_image: xcode8
+# make sure our Mac build uses latest OS X. See: https://docs.travis-ci.com/user/reference/osx/#OS-X-Version
+osx_image: xcode9
 
 before_install:
  - "if [ ${TRAVIS_OS_NAME} = 'osx' ]; then brew update && brew install libevent sqlite && brew link --force sqlite; fi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,12 @@ group: edge
 # For available compilers see: https://semitwist.com/travis-d-compilers
 d:
   - ldc
+  - dmd-2.077.1
+  - dmd-2.076.1
   - dmd-2.075.1
   - dmd-2.074.1
   - dmd-2.073.2
+  - ldc-1.5.0
   - ldc-1.4.0 # eq to dmd v2.074.1
   - ldc-1.3.0 # eq to dmd v2.073.2
   - gdc
@@ -51,7 +54,7 @@ matrix:
       before_script: mysql -e 'CREATE DATABASE ddbctest;'
       script:
         - dub build --config=full
-        - cd example && dub build && ./ddbctest --connection=mysql:127.0.0.1 --database=ddbctest --user=root
+        - cd example && dub build && ./ddbctest --connection=mysql:127.0.0.1 --database=test --user=ddbctest
     - env: NAME="PostgreSQL Integration Test"
       d: dmd
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,15 @@ addons:
 # The integration tests can only run in Linux container
 matrix:
   include:
+    - env: NAME="MySQL Integration Test with DUB upgrade"
+      d: dmd
+      os: linux
+      service: mysql
+      before_script: mysql -e 'CREATE DATABASE ddbctest;'
+      script:
+        - dub upgrade
+        - dub build --config=full
+        - cd example && dub build && ./ddbctest --connection=mysql:127.0.0.1 --database=ddbctest --user=root
     - env: NAME="MySQL Integration Test"
       d: dmd
       os: linux

--- a/dub.json
+++ b/dub.json
@@ -12,7 +12,7 @@
             "name": "full",
             "versions": ["USE_MYSQL", "USE_SQLITE", "USE_PGSQL"],
             "dependencies": {
-                "mysql-native": "~>1.1.0",
+                "mysql-native": "~>1.1.3",
                 "derelict-pq": "~>2.2.0"
             },
             "libs-posix": ["sqlite3"],
@@ -27,7 +27,7 @@
             "name": "MySQL",
             "versions": ["USE_MYSQL"],
             "dependencies": {
-                "mysql-native": "~>1.1.0"
+                "mysql-native": "~>1.1.3"
             }
         },
         {

--- a/dub.json
+++ b/dub.json
@@ -12,7 +12,7 @@
             "name": "full",
             "versions": ["USE_MYSQL", "USE_SQLITE", "USE_PGSQL"],
             "dependencies": {
-                "mysql-native": "~>1.1.3",
+                "mysql-native": ">=1.1.3 <=1.2.0",
                 "derelict-pq": "~>2.2.0"
             },
             "libs-posix": ["sqlite3"],
@@ -27,7 +27,7 @@
             "name": "MySQL",
             "versions": ["USE_MYSQL"],
             "dependencies": {
-                "mysql-native": "~>1.1.3"
+                "mysql-native": ">=1.1.3 <=1.2.0"
             }
         },
         {

--- a/example/source/testddbc.d
+++ b/example/source/testddbc.d
@@ -187,9 +187,20 @@ int main(string[] args)
             break;
     }
 
-	// reading DB
+	writeln("testing normal SQL statements");
 	auto rs = stmt.executeQuery("SELECT id, name name_alias, comment, ts FROM ddbct1 ORDER BY id");
 	while (rs.next())
-	writeln(to!string(rs.getLong(1)) ~ "\t" ~ rs.getString(2) ~ "\t" ~ rs.getString(3)); // rs.getString(3) was wrapped with strNull - not sure what this did
+	    writeln(to!string(rs.getLong(1)) ~ "\t" ~ rs.getString(2) ~ "\t" ~ rs.getString(3)); // rs.getString(3) was wrapped with strNull - not sure what this did
+
+
+    writeln("testing prepared statements");
+	PreparedStatement ps2 = conn.prepareStatement("SELECT id, name name_alias, comment, ts FROM ddbct1 WHERE id >= ?");
+    scope(exit) ps2.close();
+    ps2.setUlong(1, 1);
+    auto prs = ps2.executeQuery();
+    while (prs.next()) {
+        writeln(to!string(prs.getLong(1)) ~ "\t" ~ prs.getString(2) ~ "\t" ~ prs.getString(3));
+    }
+
 	return 0;
 }


### PR DESCRIPTION
in mysql-native, _Command_ was deprecated and has been removed alltogether in v1.2.0. The changes in this PR do away with the need for Command and will work with 1.1.* versions as well as v1.2.0, it also seems to resolve an issue I previously had with the way prepared statements worked.
I've also updated the travis file to use more recent compiler versions and added a new job that runs `dub upgrade` prior to building/testing.