### PR TITLE
pgsql: Add very basic support for JSON/JSONB types

### DIFF
--- a/source/ddbc/drivers/pgsqlddbc.d
+++ b/source/ddbc/drivers/pgsqlddbc.d
@@ -57,6 +57,7 @@ version(USE_PGSQL) {
     const int CIDOID = 29;
     const int OIDVECTOROID = 30;
     const int JSONOID = 114;
+    const int JSONBOID = 3802;
     const int XMLOID = 142;
     const int PGNODETREEOID = 194;
     const int POINTOID = 600;
@@ -556,6 +557,12 @@ version(USE_PGSQL) {
                                     v[col] = parseDateoid(s);
                                     break;
                                 case UUIDOID:
+                                    v[col] = s;
+                                    break;
+                                case JSONOID:
+                                    v[col] = s;
+                                    break;
+                                case JSONBOID:
                                     v[col] = s;
                                     break;
                                 default:


### PR DESCRIPTION
This simple patch makes ddbc recognize PostgreSQLs native JSON types. Both types don't receive special treatment for now, they are just treated as strings.
In future, we can maybe do something cool, like parsing the JSON into a struct automatically, or using Postgres' binary transfer and then convert jsonb to Vibe.d's BSON...

The dpq2 library is doing some cool stuff on that front.
