### PR TITLE
Cannot get columns by name

### DIFF
--- a/source/ddbc/drivers/sqliteddbc.d
+++ b/source/ddbc/drivers/sqliteddbc.d
@@ -640,7 +640,9 @@ version(USE_SQLITE) {
             this.rs = rs;
             this.metadata = metadata;
             closed = false;
-            this.columnCount = sqlite3_data_count(rs); //metadata.getColumnCount();
+            // The column count cannot use sqlite3_data_count, because sqlite3_step has not yet been used with this result set.
+            // Because there are not results ready to return, sqlite3_data_count will return 0 causing no columns to be mapped.
+            this.columnCount = metadata.getColumnCount();
             for (int i=0; i<columnCount; i++) {
                 columnMap[metadata.getColumnName(i + 1)] = i;
             }


### PR DESCRIPTION
It is not possible to get a column by name from a result set with sqlite, because the column map is not getting populated.

Here is an example program using 0.3.8 that shows the issue when the write statements are swapped.

```
import std.stdio;

import ddbc;

void main() {
    auto conn = createConnection("sqlite:memory");
    auto stmt = conn.createStatement();
    scope(exit) stmt.close();

    stmt.executeUpdate("DROP TABLE IF EXISTS bug");
    stmt.executeUpdate("CREATE TABLE bug (name NVARCHAR(10), value SMALLINT)");
    stmt.executeUpdate("INSERT INTO bug (name,value) VALUES ('alpha',1)");

    auto rs = stmt.executeQuery("SELECT * FROM bug");
    if (rs.next()) {
        // swapping these two lines will fail without corrective action.
        writeln("name='", rs.getString(1), "'; value=", rs.getInt(2));
        // writeln("name='", rs.getString("name"), "'; value=", rs.getInt("value"));
    } else {
        writeln("No rows returned.");
    }
}
```