### PR TITLE
Select support uda

### DIFF
--- a/example/source/testddbc.d
+++ b/example/source/testddbc.d
@@ -430,6 +430,22 @@ int main(string[] args)
         DateTime created;
         SysTime updated;
     }
+    
+    // with UDA
+    @tableName("employee")
+    struct Employee2 {
+        struct Proxy {
+            static long to(string src) { return std.conv.to!long(src); }
+            static string from(long src) { return std.conv.to!string(src); }
+        }
+        @convBy!Proxy       string id;
+        @ignore             string hogehoge;
+        @columnName("name") string nameOfEnployee;
+        int flags;
+        Date dob;
+        DateTime created;
+        SysTime updated;
+    }
 
 	immutable SysTime now = Clock.currTime();
 
@@ -445,10 +461,10 @@ int main(string[] args)
     }
 
     writeln(" > select all rows from employee table WHERE id < 4 ORDER BY name DESC...");
-    foreach(ref e; conn.createStatement().select!Employee.where("id < 4").orderBy("name desc")) {
-        writeln("\t{id: ", e.id, ", name: ", e.name, ", flags: ", e.flags, ", dob: ", e.dob, ", created: ", e.created, ", updated: ", e.updated, "}");
-		assert(e.id < 4);
-		assert(e.name != "Iain" && e.name != "Robert");
+    foreach(ref e; conn.createStatement().select!Employee2.where("id < 4").orderBy("name desc")) {
+        writeln("\t{id: ", e.id, ", name: ", e.nameOfEnployee, ", flags: ", e.flags, ", dob: ", e.dob, ", created: ", e.created, ", updated: ", e.updated, "}");
+		assert(e.id.to!int < 4);
+		assert(e.nameOfEnployee != "Iain" && e.nameOfEnployee != "Robert");
 		assert(e.flags > 1);
     }
 

--- a/source/ddbc/all.d
+++ b/source/ddbc/all.d
@@ -16,6 +16,7 @@
 module ddbc.all;
 
 public import ddbc.core;
+public import ddbc.attr;
 public import ddbc.common;
 public import ddbc.pods;
 

--- a/source/ddbc/attr.d
+++ b/source/ddbc/attr.d
@@ -31,10 +31,10 @@ enum ignore;
 ///
 struct convBy(alias T){}
 
-package:
+package(ddbc):
 
 ///
-template hasTableName(alias value) {
+template hasTableName(value...) {
     static if (__traits(compiles, hasUDA!(value, tableName))) {
         enum bool hasTableName = hasUDA!(value, tableName);
     } else {
@@ -168,7 +168,13 @@ template getConvToStyle(alias value, Ret) if (hasConvBy!value) {
 }
 
 ///
-enum canConvTo(alias value, T) = hasConvBy!value && getConvToStyle!(value, T) != ConvStyle.none;
+template canConvTo(alias value, T) {
+    static if (hasConvBy!value) {
+        enum bool canConvTo = getConvToStyle!(value, T) != ConvStyle.none;
+    } else {
+        enum bool canConvTo = false;
+    }
+}
 
 
 ///
@@ -220,7 +226,13 @@ template getConvFromStyle(alias value, Src) if (hasConvBy!value) {
     }
 }
 ///
-enum canConvFrom(alias value, T) = hasConvBy!value && getConvFromStyle!(value, T) != ConvStyle.none;
+template canConvFrom(alias value, T) {
+    static if (hasConvBy!value) {
+        enum bool canConvFrom = getConvFromStyle!(value, T) != ConvStyle.none;
+    } else {
+        enum bool canConvFrom = false;
+    }
+}
 
 ///
 template convFrom(alias value, Src)

--- a/source/ddbc/attr.d
+++ b/source/ddbc/attr.d
@@ -1,0 +1,456 @@
+/**
+ * DDBC - D DataBase Connector - abstraction layer for RDBMS access, with interface similar to JDBC. 
+ * 
+ * Source file ddbc/attr.d.
+ * 
+ * Copyright: Copyright 2020
+ * License:   $(LINK www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Author:    SHOO
+ */
+module ddbc.attr;
+
+import std.traits;
+import std.meta;
+
+///
+struct tableName {
+    ///
+    string name;
+}
+
+
+///
+struct columnName {
+    ///
+    string name;
+}
+
+///
+enum ignore;
+
+///
+struct convBy(alias T){}
+
+package:
+
+///
+template hasTableName(alias value) {
+    static if (__traits(compiles, hasUDA!(value, tableName))) {
+        enum bool hasTableName = hasUDA!(value, tableName);
+    } else {
+        enum bool hasTableName = false;
+    }
+}
+///
+enum string getTableName(alias value) = getUDAs!(value, tableName)[0].name;
+
+///
+enum bool   hasColumnName(alias value) = hasUDA!(value, columnName);
+
+///
+enum string getColumnName(alias value) = getUDAs!(value, columnName)[0].name;
+
+///
+enum bool   hasIgnore(alias value) = hasUDA!(value, ignore);
+
+unittest {
+    @tableName("a")
+    struct A {
+        @columnName("test")
+        int test;
+        
+        @ignore
+        int foo;
+    }
+    
+    struct B { int test; }
+    
+    A a;
+    B b;
+    
+    static assert( hasTableName!A);
+    static assert(!hasTableName!B);
+    static assert(!hasTableName!a);
+    static assert(!hasTableName!b);
+    static assert(!hasTableName!int);
+    
+    static assert(getTableName!A == "a");
+    
+    static assert(!hasColumnName!A);
+    static assert( hasColumnName!(a.test));
+    static assert(!hasColumnName!(b.test));
+    
+    static assert(getColumnName!(a.test) == "test");
+    
+    static assert(!hasIgnore!(a.test));
+    static assert(!hasIgnore!(b.test));
+    static assert( hasIgnore!(a.foo));
+}
+
+
+///
+enum bool isConvByAttr(alias Attr) = isInstanceOf!(convBy, Attr);
+
+///
+template getConvByAttr(alias Attr) if (isConvByAttr!Attr) {
+    alias getConvByAttr = TemplateArgsOf!(Attr)[0];
+}
+
+///
+alias ProxyList(alias value) = staticMap!(getConvByAttr, Filter!(isConvByAttr, __traits(getAttributes, value)));
+
+///
+template getConvBy(alias value) {
+    private alias _list = ProxyList!value;
+    static assert(_list.length <= 1, `Only single serialization proxy is allowed`);
+    alias getConvBy = _list[0];
+}
+
+///
+template hasConvBy(alias value) {
+    private enum _listLength = ProxyList!value.length;
+    static assert(_listLength <= 1, `Only single serialization proxy is allowed`);
+    enum bool hasConvBy = _listLength == 1;
+}
+
+unittest {
+    struct Proxy {
+        static string to(ref int value) { return null; }
+        static int from(string value)   { return 0; }
+    }
+    struct A {
+        @convBy!Proxy int a;
+        @(42) int b;
+        @(42) @convBy!Proxy int c;
+    }
+    static assert(isConvByAttr!(__traits(getAttributes, A.a)));
+    static assert(hasConvBy!(A.a));
+    static assert(is(getConvBy!(A.a) == Proxy));
+    
+    static assert(!hasConvBy!(A.b));
+    static assert(hasConvBy!(A.c));
+}
+
+private enum ConvStyle {
+    none,
+    type1,
+    type2,
+    type3,
+    type4,
+    type5,
+    type6,
+}
+
+template getConvToStyle(alias value, Ret) if (hasConvBy!value) {
+    alias proxy = getConvBy!value;
+    static if (is(typeof(proxy.to(value)) : Ret)) {
+        // Ret dst = proxy.to(T value)
+        enum getConvToStyle = ConvStyle.type1;
+    } else static if (is(typeof(proxy.to!Ret(value)) : Ret)) {
+        // Ret dst = proxy.to!Ret(T value)
+        enum getConvToStyle = ConvStyle.type2;
+    } else static if (is(typeof(proxy.to(value, lvalueOf!Ret)))) {
+        // Ret dst; proxy.to(T value, dst);
+        enum getConvToStyle = ConvStyle.type3;
+    } else static if (is(typeof(proxy(value)) : Ret)) {
+        // Ret dst = to(T value)
+        enum getConvToStyle = ConvStyle.type4;
+    } else static if (is(typeof(proxy!Ret(value)) : Ret)) {
+        // Ret dst = to!Ret(T value);
+        enum getConvToStyle = ConvStyle.type5;
+    } else static if (is(typeof(proxy(value, lvalueOf!Ret)))) {
+        // Ret dst; move(value, dst);
+        enum getConvToStyle = ConvStyle.type6;
+    } else {
+        // no match
+        enum getConvToStyle = ConvStyle.none;
+    }
+}
+
+///
+enum canConvTo(alias value, T) = hasConvBy!value && getConvToStyle!(value, T) != ConvStyle.none;
+
+
+///
+template convTo(alias value, Dst)
+if (canConvTo!(value, Dst)) {
+    alias proxy = getConvBy!value;
+    alias Val   = typeof(value);
+    enum convToStyle = getConvToStyle!(value, Dst);
+    static if (convToStyle == ConvStyle.type1) {
+        static Dst convTo()(auto ref Val v) { return proxy.to(v); }
+    } else static if (convToStyle == ConvStyle.type2) {
+        static Dst convTo()(auto ref Val v) { return proxy.to!Dst(v); }
+    } else static if (convToStyle == ConvStyle.type3) {
+        static Dst convTo()(auto ref Val v) { Dst dst = void; proxy.to(v, dst); return dst; }
+    } else static if (convToStyle == ConvStyle.type4) {
+        static Dst convTo()(auto ref Val v) { return proxy(v); }
+    } else static if (convToStyle == ConvStyle.type5) {
+        static Dst convTo()(auto ref Val v) { return proxy!Dst(v); }
+    } else static if (convToStyle == ConvStyle.type6) {
+        static Dst convTo()(auto ref Val v) { Dst dst = void; proxy(v, dst); return dst; }
+    } else static assert(0);
+}
+
+///
+template getConvFromStyle(alias value, Src) if (hasConvBy!value) {
+    alias proxy = getConvBy!value;
+    alias Val   = typeof(value);
+    static if (is(typeof(proxy.from(lvalueOf!Src)) : Val)) {
+        // value = proxy.from(src);
+        enum getConvFromStyle = ConvStyle.type1;
+    } else static if (is(typeof(proxy.from!Val(lvalueOf!Src)) : Val)) {
+        // value = proxy.from!Src(value);
+        enum getConvFromStyle = ConvStyle.type2;
+    } else static if (is(typeof(proxy.from(lvalueOf!Src, value)))) {
+        // proxy.from(src, value);
+        enum getConvFromStyle = ConvStyle.type3;
+    } else static if (is(typeof(proxy(lvalueOf!Src)) : Val)) {
+        // value = from(src);
+        enum getConvFromStyle = ConvStyle.type4;
+    } else static if (is(typeof(proxy!Val(lvalueOf!Src)) : Val)) {
+        // value = from!Val(src);
+        enum getConvFromStyle = ConvStyle.type5;
+    } else static if (is(typeof(proxy(lvalueOf!Src, value)))) {
+        // move(src, value);
+        enum getConvFromStyle = ConvStyle.type6;
+    } else {
+        // no match
+        enum getConvFromStyle = ConvStyle.none;
+    }
+}
+///
+enum canConvFrom(alias value, T) = hasConvBy!value && getConvFromStyle!(value, T) != ConvStyle.none;
+
+///
+template convFrom(alias value, Src)
+if (canConvFrom!(value, Src)) {
+    alias proxy = getConvBy!value;
+    alias Val   = typeof(value);
+    enum convFromStyle = getConvFromStyle!(value, Src);
+    static if (convFromStyle == ConvStyle.type1) {
+        static Val convFrom()(auto ref Src v) { return proxy.from(v); }
+    } else static if (convFromStyle == ConvStyle.type2) {
+        static Val convFrom()(auto ref Src v) { return proxy.from!Val(v); }
+    } else static if (convFromStyle == ConvStyle.type3) {
+        static Val convFrom()(auto ref Src v) { Val dst = void; proxy.from(v, dst); return dst; }
+    } else static if (convFromStyle == ConvStyle.type4) {
+        static Val convFrom()(auto ref Src v) { return proxy(v); }
+    } else static if (convFromStyle == ConvStyle.type5) {
+        static Val convFrom()(auto ref Src v) { return proxy!Val(v); }
+    } else static if (convFromStyle == ConvStyle.type6) {
+        static Val convFrom()(auto ref Src v) { Val dst = void; proxy(v, dst); return dst; }
+    } else static assert(0);
+}
+
+///
+template convertTo(alias value) {
+    alias proxy = getConvBy!value;
+    alias Val   = typeof(value);
+    static void convertTo(Dst)(auto ref Val src, ref Dst dst)
+    if (canConvTo!(value, Dst)) {
+        enum convToStyle = getConvToStyle!(value, Dst);
+        static if (convToStyle == ConvStyle.type1) {
+            dst = proxy.to(src);
+        } else static if (convToStyle == ConvStyle.type2) {
+            dst = proxy.to!Dst(src);
+        } else static if (convToStyle == ConvStyle.type3) {
+            proxy.to(src, dst);
+        } else static if (convToStyle == ConvStyle.type4) {
+            dst = proxy(src);
+        } else static if (convToStyle == ConvStyle.type5) {
+            dst = proxy!Dst(src);
+        } else static if (convToStyle == ConvStyle.type6) {
+            proxy(src, dst);
+        } else static assert(0);
+    }
+}
+
+///
+template convertFrom(alias value) {
+    alias proxy = getConvBy!value;
+    alias Val   = typeof(value);
+    static void convertFrom(Src)(auto ref Src src, ref Val dst)
+    if (canConvFrom!(value, Src)) {
+        enum convFromStyle = getConvFromStyle!(value, Src);
+        static if (convFromStyle == ConvStyle.type1) {
+            dst = proxy.from(src);
+        } else static if (convFromStyle == ConvStyle.type2) {
+            dst = proxy.from!Val(src);
+        } else static if (convFromStyle == ConvStyle.type3) {
+            proxy.from(src, dst);
+        } else static if (convFromStyle == ConvStyle.type4) {
+            dst = proxy(src);
+        } else static if (convFromStyle == ConvStyle.type5) {
+            dst = proxy!Val(src);
+        } else static if (convFromStyle == ConvStyle.type6) {
+            proxy(src, dst);
+        } else static assert(0);
+    }
+}
+
+
+///
+enum isConvertible(alias value, T) = canConvTo!(value, T) && canConvFrom!(value, T);
+
+
+unittest {
+    import std.conv;
+    alias toInt = std.conv.to!int;
+    struct Proxy1 {
+        static string to(ref int value) { return text(value) ~ "1"; }
+        static int from(string value)   { return toInt(value) + 111; }
+    }
+    struct Proxy2 {
+        static T to(T)(ref int value)  { return text(value) ~ "2"; }
+        static T from(T)(string value) { return toInt(value) + 222; }
+    }
+    struct Proxy3 {
+        static void to(int value, ref string dst)   { dst = text(value) ~ "3"; }
+        static void from(string value, ref int dst) { dst = toInt(value) + 333; }
+    }
+    static string proxy4to(int value)      { return text(value) ~ "4"; }
+    static int proxy4from(string value)    { return toInt(value) + 444; }
+    static T proxy5to(T)(int value)        { return text(value) ~ "5"; }
+    static T proxy5from(T)(string value)   { return toInt(value) + 555; }
+    static void proxy6to(int src, ref string dst)      { dst = text(src) ~ "6"; }
+    static void proxy6from(string src, ref int dst)    { dst = toInt(src) + 666; }
+    static void proxy7to(T)(int src, ref T dst)        { dst = text(src) ~ "7"; }
+    static void proxy7from(T)(string src, ref T dst)   { dst = toInt(src) + 777; }
+    struct Proxy8 {
+        static void to(int src, ref int dst)    { dst = 0; }
+        static void to(int src, ref string dst) { dst = text(src) ~ "8"; }
+        static void from(string src, ref int dst)    { dst = toInt(src) + 888; }
+        static void from(string src, ref string dst) { dst = null; }
+    }
+    static void proxy9(int src) { }
+    static string proxy10(int src) { return null; }
+    struct A {
+        @convBy!Proxy1        int a;
+        @convBy!Proxy2        int b;
+        @convBy!Proxy3        int c;
+        @convBy!proxy4to      int d1;
+        @convBy!proxy5to      int e1;
+        @convBy!proxy6to      int f1;
+        @convBy!proxy7to      int g1;
+        @convBy!(Proxy8.to)   int h1;
+        @convBy!proxy4from    int d2;
+        @convBy!proxy5from    int e2;
+        @convBy!proxy6from    int f2;
+        @convBy!proxy7from    int g2;
+        @convBy!(Proxy8.from) int h2;
+        @convBy!Proxy8        int h;
+        @convBy!proxy9        int i;
+        int j;
+        @convBy!proxy10       int k;
+    }
+    static assert(getConvToStyle!(A.a, string) == ConvStyle.type1);
+    static assert(getConvToStyle!(A.b, string) == ConvStyle.type2);
+    static assert(getConvToStyle!(A.c, string) == ConvStyle.type3);
+    static assert(getConvToStyle!(A.d1, string) == ConvStyle.type4);
+    static assert(getConvToStyle!(A.e1, string) == ConvStyle.type5);
+    static assert(getConvToStyle!(A.f1, string) == ConvStyle.type6);
+    static assert(getConvToStyle!(A.g1, string) == ConvStyle.type6);
+    static assert(getConvToStyle!(A.h1, string) == ConvStyle.type6);
+    
+    static assert(getConvFromStyle!(A.a, string) == ConvStyle.type1);
+    static assert(getConvFromStyle!(A.b, string) == ConvStyle.type2);
+    static assert(getConvFromStyle!(A.c, string) == ConvStyle.type3);
+    static assert(getConvFromStyle!(A.d2, string) == ConvStyle.type4);
+    static assert(getConvFromStyle!(A.e2, string) == ConvStyle.type5);
+    static assert(getConvFromStyle!(A.f2, string) == ConvStyle.type6);
+    static assert(getConvFromStyle!(A.g2, string) == ConvStyle.type6);
+    static assert(getConvFromStyle!(A.h2, string) == ConvStyle.type6);
+    
+    static assert(getConvToStyle!(A.h, string)   == ConvStyle.type3);
+    static assert(getConvFromStyle!(A.h, string) == ConvStyle.type3);
+    static assert(getConvToStyle!(A.i, string) == ConvStyle.none);
+    static assert(!__traits(compiles, getConvToStyle!(A.j, string)));
+    static assert( canConvTo!(A.a, string));
+    static assert(!canConvTo!(A.i, string));
+    static assert(!canConvTo!(A.j, string));
+    static assert( canConvFrom!(A.a, string));
+    static assert(!canConvFrom!(A.i, string));
+    static assert(!canConvFrom!(A.j, string));
+    static assert( isConvertible!(A.a, string));
+    static assert(!isConvertible!(A.a, real));
+    static assert( canConvTo!(A.k, string));
+    static assert(!canConvFrom!(A.k, string));
+    static assert(!isConvertible!(A.k, string));
+    
+    A foo;
+    foo.a = 10;
+    foo.b = 20;
+    foo.c = 30;
+    foo.d1 = 40;
+    foo.e1 = 50;
+    foo.f1 = 60;
+    foo.g1 = 70;
+    foo.h1 = 80;
+    
+    string str_a;
+    string str_b;
+    string str_c;
+    string str_d1;
+    string str_e1;
+    string str_f1;
+    string str_g1;
+    string str_h1;
+    
+    assert(convTo!(foo.a, string)(foo.a) == "101");
+    assert(convTo!(foo.b, string)(foo.b) == "202");
+    assert(convTo!(foo.c, string)(foo.c) == "303");
+    assert(convTo!(foo.d1, string)(foo.d1) == "404");
+    assert(convTo!(foo.e1, string)(foo.e1) == "505");
+    assert(convTo!(foo.f1, string)(foo.f1) == "606");
+    assert(convTo!(foo.g1, string)(foo.g1) == "707");
+    assert(convTo!(foo.h1, string)(foo.h1) == "808");
+    
+    convertTo!(foo.a )(foo.a,  str_a);
+    convertTo!(foo.b )(foo.b,  str_b);
+    convertTo!(foo.c )(foo.c,  str_c);
+    convertTo!(foo.d1)(foo.d1, str_d1);
+    convertTo!(foo.e1)(foo.e1, str_e1);
+    convertTo!(foo.f1)(foo.f1, str_f1);
+    convertTo!(foo.g1)(foo.g1, str_g1);
+    convertTo!(foo.h1)(foo.h1, str_h1);
+    
+    assert(str_a  == "101");
+    assert(str_b  == "202");
+    assert(str_c  == "303");
+    assert(str_d1 == "404");
+    assert(str_e1 == "505");
+    assert(str_f1 == "606");
+    assert(str_g1 == "707");
+    assert(str_h1 == "808");
+    
+    assert(convFrom!(foo.a,  string)("1000") == 1111);
+    assert(convFrom!(foo.b,  string)("1000") == 1222);
+    assert(convFrom!(foo.c,  string)("1000") == 1333);
+    assert(convFrom!(foo.d2, string)("1000") == 1444);
+    assert(convFrom!(foo.e2, string)("1000") == 1555);
+    assert(convFrom!(foo.f2, string)("1000") == 1666);
+    assert(convFrom!(foo.g2, string)("1000") == 1777);
+    assert(convFrom!(foo.h2, string)("1000") == 1888);
+    
+    convertFrom!(foo.a)(  "1000", foo.a  );
+    convertFrom!(foo.b)(  "1000", foo.b  );
+    convertFrom!(foo.c)(  "1000", foo.c  );
+    convertFrom!(foo.d2)( "1000", foo.d2 );
+    convertFrom!(foo.e2)( "1000", foo.e2 );
+    convertFrom!(foo.f2)( "1000", foo.f2 );
+    convertFrom!(foo.g2)( "1000", foo.g2 );
+    convertFrom!(foo.h2)( "1000", foo.h2 );
+    
+    assert(foo.a  == 1111);
+    assert(foo.b  == 1222);
+    assert(foo.c  == 1333);
+    assert(foo.d2 == 1444);
+    assert(foo.e2 == 1555);
+    assert(foo.f2 == 1666);
+    assert(foo.g2 == 1777);
+    assert(foo.h2 == 1888);
+}
+
+
+

--- a/source/ddbc/package.d
+++ b/source/ddbc/package.d
@@ -176,6 +176,7 @@ If you need to get / release connection multiple times, it makes sense to use Co
 module ddbc;
 
 public import ddbc.core;
+public import ddbc.attr;
 public import ddbc.common;
 public import ddbc.pods;
 

--- a/source/ddbc/pods.d
+++ b/source/ddbc/pods.d
@@ -59,6 +59,7 @@ import std.variant;
 static import std.ascii;
 
 import ddbc.core;
+import ddbc.attr;
 
 alias Nullable!byte Byte;
 alias Nullable!ubyte Ubyte;
@@ -134,6 +135,17 @@ enum PropertyMemberType : int {
     NULLABLE_TIME_TYPE, // Nullable!std.datetime.TimeOfDay
     BYTE_ARRAY_TYPE, // byte[]
     UBYTE_ARRAY_TYPE, // ubyte[]
+    
+    LONG_CONVERTIBLE_TYPE,                      // @convBy!Proxy for long
+    ULONG_CONVERTIBLE_TYPE,                     // @convBy!Proxy for ulong
+    NULLABLE_LONG_CONVERTIBLE_TYPE,             // @convBy!Proxy for Nullable!long
+    NULLABLE_ULONG_CONVERTIBLE_TYPE,            // @convBy!Proxy for Nullable!ulong
+    DOUBLE_CONVERTIBLE_TYPE,                    // @convBy!Proxy for double
+    NULLABLE_DOUBLE_CONVERTIBLE_TYPE,           // @convBy!Proxy for Nullable!double
+    STRING_CONVERTIBLE_TYPE,                    // @convBy!Proxy for string
+    NULLABLE_STRING_CONVERTIBLE_TYPE,           // @convBy!Proxy for String
+    BYTE_ARRAY_CONVERTIBLE_TYPE,                // @convBy!Proxy for byte[]
+    UBYTE_ARRAY_CONVERTIBLE_TYPE,               // @convBy!Proxy for ubyte[]
 }
 
 /// converts camel case MyEntityName to my_entity_name
@@ -165,9 +177,33 @@ unittest {
 }
 
 
-template isSupportedSimpleType(T, string m) {
-    alias typeof(__traits(getMember, T, m)) ti;
-    static if (is(ti == function)) {
+template isSupportedSimpleType(alias value) {
+    alias ti = typeof(value);
+    static if (hasConvBy!value) {
+        static if (isConvertible!(value, long)) {
+            enum bool isSupportedSimpleType = true;
+        } else static if (isConvertible!(value, ulong)) {
+            enum bool isSupportedSimpleType = true;
+        } else static if (isConvertible!(value, double)) {
+            enum bool isSupportedSimpleType = true;
+        } else static if (isConvertible!(value, Nullable!long)) {
+            enum bool isSupportedSimpleType = true;
+        } else static if (isConvertible!(value, Nullable!ulong)) {
+            enum bool isSupportedSimpleType = true;
+        } else static if (isConvertible!(value, Nullable!double)) {
+            enum bool isSupportedSimpleType = true;
+        } else static if (isConvertible!(value, string)) {
+            enum bool isSupportedSimpleType = true;
+        } else static if (isConvertible!(value, String)) {
+            enum bool isSupportedSimpleType = true;
+        } else static if (isConvertible!(value, byte[])) {
+            enum bool isSupportedSimpleType = true;
+        } else static if (isConvertible!(value, ubyte[])) {
+            enum bool isSupportedSimpleType = true;
+        } else static if (true) {
+            enum bool isSupportedSimpleType = false;
+        }
+    } else static if (is(ti == function)) {
         static if (is(ReturnType!(ti) == bool)) {
             enum bool isSupportedSimpleType = true;
         } else static if (is(ReturnType!(ti) == byte)) {
@@ -308,11 +344,37 @@ template isSupportedSimpleType(T, string m) {
     }
 }
 
-PropertyMemberType getPropertyType(ti)() {
+enum isSupportedSimpleType(T, string m) = isSupportedSimpleType!(__traits(getMember, T, m));
+
+PropertyMemberType getPropertyType(alias value)() {
     //pragma(msg, T.stringof);
-    //alias typeof(T) ti;
-	static if (is(ti == bool)) {
-		return PropertyMemberType.BOOL_TYPE;
+    alias ti = typeof(value);
+    static if (hasConvBy!value) {
+        static if (isConvertible!(value, long)) {
+            return PropertyMemberType.LONG_CONVERTIBLE_TYPE;
+        } else static if (isConvertible!(value, ulong)) {
+            return PropertyMemberType.ULONG_CONVERTIBLE_TYPE;
+        } else static if (isConvertible!(value, double)) {
+            return PropertyMemberType.DOUBLE_CONVERTIBLE_TYPE;
+        } else static if (isConvertible!(value, Nullable!long)) {
+            return PropertyMemberType.NULLABLE_LONG_CONVERTIBLE_TYPE;
+        } else static if (isConvertible!(value, Nullable!ulong)) {
+            return PropertyMemberType.NULLABLE_ULONG_CONVERTIBLE_TYPE;
+        } else static if (isConvertible!(value, Nullable!double)) {
+            return PropertyMemberType.NULLABLE_DOUBLE_CONVERTIBLE_TYPE;
+        } else static if (isConvertible!(value, string)) {
+            return PropertyMemberType.STRING_CONVERTIBLE_TYPE;
+        } else static if (isConvertible!(value, String)) {
+            return PropertyMemberType.NULLABLE_STRING_CONVERTIBLE_TYPE;
+        } else static if (isConvertible!(value, byte[])) {
+            return PropertyMemberType.BYTE_ARRAY_CONVERTIBLE_TYPE;
+        } else static if (isConvertible!(value, ubyte[])) {
+            return PropertyMemberType.UBYTE_ARRAY_CONVERTIBLE_TYPE;
+        } else static if (true) {
+            static assert (false, "has unsupported type " ~ ti.stringof);
+        }
+    } else static if (is(ti == bool)) {
+        return PropertyMemberType.BOOL_TYPE;
     } else static if (is(ti == byte)) {
         return PropertyMemberType.BYTE_TYPE;
     } else static if (is(ti == short)) {
@@ -384,7 +446,32 @@ PropertyMemberType getPropertyType(ti)() {
 
 PropertyMemberType getPropertyMemberType(T, string m)() {
     alias typeof(__traits(getMember, T, m)) ti;
-    static if (is(ti == bool)) {
+    alias member = __traits(getMember, T, m);
+    static if (hasConvBy!member) {
+        static if (isConvertible!(member, long)) {
+            return PropertyMemberType.LONG_CONVERTIBLE_TYPE;
+        } else static if (isConvertible!(member, ulong)) {
+            return PropertyMemberType.ULONG_CONVERTIBLE_TYPE;
+        } else static if (isConvertible!(member, double)) {
+            return PropertyMemberType.DOUBLE_CONVERTIBLE_TYPE;
+        } else static if (isConvertible!(member, Nullable!long)) {
+            return PropertyMemberType.NULLABLE_LONG_CONVERTIBLE_TYPE;
+        } else static if (isConvertible!(member, Nullable!ulong)) {
+            return PropertyMemberType.NULLABLE_ULONG_CONVERTIBLE_TYPE;
+        } else static if (isConvertible!(member, Nullable!double)) {
+            return PropertyMemberType.NULLABLE_DOUBLE_CONVERTIBLE_TYPE;
+        } else static if (isConvertible!(member, string)) {
+            return PropertyMemberType.STRING_CONVERTIBLE_TYPE;
+        } else static if (isConvertible!(member, String)) {
+            return PropertyMemberType.NULLABLE_STRING_CONVERTIBLE_TYPE;
+        } else static if (isConvertible!(member, byte[])) {
+            return PropertyMemberType.BYTE_ARRAY_CONVERTIBLE_TYPE;
+        } else static if (isConvertible!(member, ubyte[])) {
+            return PropertyMemberType.UBYTE_ARRAY_CONVERTIBLE_TYPE;
+        } else static if (true) {
+            static assert (false, "Member " ~ m ~ " of class " ~ T.stringof ~ " has unsupported type " ~ ti.stringof);
+        }
+    } else static if (is(ti == bool)) {
         return PropertyMemberType.BOOL_TYPE;
     } else static if (is(ti == byte)) {
         return PropertyMemberType.BYTE_TYPE;
@@ -498,6 +585,17 @@ static immutable bool[] ColumnTypeCanHoldNulls =
     true, //NULLABLE_TIME_TYPE, // Nullable!std.datetime.TimeOfDay
     true, //BYTE_ARRAY_TYPE, // byte[]
     true, //UBYTE_ARRAY_TYPE, // ubyte[]
+    
+    false, //LONG_CONVERTIBLE_TYPE,                      // @convBy!Proxy for long
+    false, //ULONG_CONVERTIBLE_TYPE,                     // @convBy!Proxy for ulong
+    true,  //NULLABLE_LONG_CONVERTIBLE_TYPE,             // @convBy!Proxy for Nullable!long
+    true,  //NULLABLE_ULONG_CONVERTIBLE_TYPE,            // @convBy!Proxy for Nullable!ulong
+    false, //DOUBLE_CONVERTIBLE_TYPE,                    // @convBy!Proxy for double
+    true,  //NULLABLE_DOUBLE_CONVERTIBLE_TYPE,           // @convBy!Proxy for Nullable!double
+    false, //STRING_CONVERTIBLE_TYPE,                    // @convBy!Proxy for string
+    true,  //NULLABLE_STRING_CONVERTIBLE_TYPE,           // @convBy!Proxy for String
+    true,  //BYTE_ARRAY_CONVERTIBLE_TYPE,                // @convBy!Proxy for byte[]
+    true,  //UBYTE_ARRAY_CONVERTIBLE_TYPE,               // @convBy!Proxy for ubyte[]
 ];
 
 bool isColumnTypeNullableByDefault(T, string m)() {
@@ -539,6 +637,17 @@ static immutable string[] ColumnTypeKeyIsSetCode =
     "(!%s.isNull)", //NULLABLE_TIME_TYPE, // Nullable!std.datetime.TimeOfDay
     "(%s !is null)", //BYTE_ARRAY_TYPE, // byte[]
     "(%s !is null)", //UBYTE_ARRAY_TYPE, // ubyte[]
+    
+    "(%s != 0)",     //LONG_CONVERTIBLE_TYPE,                      // @convBy!Proxy for long
+    "(%s != 0)",     //ULONG_CONVERTIBLE_TYPE,                     // @convBy!Proxy for ulong
+    "(!%s.isNull)",  //NULLABLE_LONG_CONVERTIBLE_TYPE,             // @convBy!Proxy for Nullable!long
+    "(!%s.isNull)",  //NULLABLE_ULONG_CONVERTIBLE_TYPE,            // @convBy!Proxy for Nullable!ulong
+    "(%s != 0)",     //DOUBLE_CONVERTIBLE_TYPE,                    // @convBy!Proxy for double
+    "(!%s.isNull)",  //NULLABLE_DOUBLE_CONVERTIBLE_TYPE,           // @convBy!Proxy for Nullable!double
+    "(%s !is null)", //STRING_CONVERTIBLE_TYPE,                    // @convBy!Proxy for string
+    "(!%s.isNull)",  //NULLABLE_STRING_CONVERTIBLE_TYPE,           // @convBy!Proxy for String
+    "(%s !is null)", //BYTE_ARRAY_CONVERTIBLE_TYPE,                // @convBy!Proxy for byte[]
+    "(%s !is null)", //UBYTE_ARRAY_CONVERTIBLE_TYPE,               // @convBy!Proxy for ubyte[]
 ];
 
 string getColumnTypeKeyIsSetCode(T, string m)() {
@@ -580,6 +689,17 @@ static immutable string[] ColumnTypeIsNullCode =
     "(%s.isNull)", //NULLABLE_TIME_TYPE, // Nullable!std.datetime.TimeOfDay
     "(%s is null)", //BYTE_ARRAY_TYPE, // byte[]
     "(%s is null)", //UBYTE_ARRAY_TYPE, // ubyte[]
+    
+    "(false)",      //LONG_CONVERTIBLE_TYPE,                      // @convBy!Proxy for long
+    "(false)",      //ULONG_CONVERTIBLE_TYPE,                     // @convBy!Proxy for ulong
+    "(%s.isNull)",  //NULLABLE_LONG_CONVERTIBLE_TYPE,             // @convBy!Proxy for Nullable!long
+    "(%s.isNull)",  //NULLABLE_ULONG_CONVERTIBLE_TYPE,            // @convBy!Proxy for Nullable!ulong
+    "(false)",      //DOUBLE_CONVERTIBLE_TYPE,                    // @convBy!Proxy for double
+    "(%s.isNull)",  //NULLABLE_DOUBLE_CONVERTIBLE_TYPE,           // @convBy!Proxy for Nullable!double
+    "(%s is null)", //STRING_CONVERTIBLE_TYPE,                    // @convBy!Proxy for string
+    "(%s.isNull)",  //NULLABLE_STRING_CONVERTIBLE_TYPE,           // @convBy!Proxy for String
+    "(%s is null)", //BYTE_ARRAY_CONVERTIBLE_TYPE,                // @convBy!Proxy for byte[]
+    "(%s is null)", //UBYTE_ARRAY_CONVERTIBLE_TYPE,               // @convBy!Proxy for ubyte[]
 ];
 
 string getColumnTypeIsNullCode(T, string m)() {
@@ -621,6 +741,17 @@ static immutable string[] ColumnTypeSetNullCode =
     "Nullable!TimeOfDay nv;", //NULLABLE_TIME_TYPE, // Nullable!std.datetime.TimeOfDay
     "byte[] nv = null;", //BYTE_ARRAY_TYPE, // byte[]
     "ubyte[] nv = null;", //UBYTE_ARRAY_TYPE, // ubyte[]
+    
+    "long nv = 0;",        //LONG_CONVERTIBLE_TYPE,                      // @convBy!Proxy for long
+    "ulong nv = 0;",       //ULONG_CONVERTIBLE_TYPE,                     // @convBy!Proxy for ulong
+    "Nullable!long nv;",   //NULLABLE_LONG_CONVERTIBLE_TYPE,             // @convBy!Proxy for Nullable!long
+    "Nullable!ulong nv;",  //NULLABLE_ULONG_CONVERTIBLE_TYPE,            // @convBy!Proxy for Nullable!ulong
+    "double nv = 0;",      //DOUBLE_CONVERTIBLE_TYPE,                    // @convBy!Proxy for double
+    "Nullable!double nv;", //NULLABLE_DOUBLE_CONVERTIBLE_TYPE,           // @convBy!Proxy for Nullable!double
+    "string nv;",          //STRING_CONVERTIBLE_TYPE,                    // @convBy!Proxy for string
+    "string nv;",          //NULLABLE_STRING_CONVERTIBLE_TYPE,           // @convBy!Proxy for String
+    "byte[] nv = null;",   //BYTE_ARRAY_CONVERTIBLE_TYPE,                // @convBy!Proxy for byte[]
+    "ubyte[] nv = null;",  //UBYTE_ARRAY_CONVERTIBLE_TYPE,               // @convBy!Proxy for ubyte[]
 ];
 
 static immutable string[] ColumnTypePropertyToVariant = 
@@ -658,6 +789,17 @@ static immutable string[] ColumnTypePropertyToVariant =
     "(%s.isNull ? Variant(null) : Variant(%s.get()))", //NULLABLE_TIME_TYPE, // Nullable!std.datetime.TimeOfDay
     "Variant(%s)", //BYTE_ARRAY_TYPE, // byte[]
     "Variant(%s)", //UBYTE_ARRAY_TYPE, // ubyte[]
+    
+    "Variant(%s)", //LONG_CONVERTIBLE_TYPE,                      // @convBy!Proxy for long
+    "Variant(%s)", //ULONG_CONVERTIBLE_TYPE,                     // @convBy!Proxy for ulong
+    "(%s.isNull ? Variant(null) : Variant(%s.get()))", //NULLABLE_LONG_CONVERTIBLE_TYPE,             // @convBy!Proxy for Nullable!long
+    "(%s.isNull ? Variant(null) : Variant(%s.get()))", //NULLABLE_ULONG_CONVERTIBLE_TYPE,            // @convBy!Proxy for Nullable!ulong
+    "Variant(%s)", //DOUBLE_CONVERTIBLE_TYPE,                    // @convBy!Proxy for double
+    "(%s.isNull ? Variant(null) : Variant(%s.get()))", //NULLABLE_DOUBLE_CONVERTIBLE_TYPE,           // @convBy!Proxy for Nullable!double
+    "Variant(%s)", //STRING_CONVERTIBLE_TYPE,                    // @convBy!Proxy for string
+    "(%s.isNull ? Variant(null) : Variant(%s.get()))", //NULLABLE_STRING_CONVERTIBLE_TYPE,           // @convBy!Proxy for String
+    "Variant(%s)", //BYTE_ARRAY_CONVERTIBLE_TYPE,                // @convBy!Proxy for byte[]
+    "Variant(%s)", //UBYTE_ARRAY_CONVERTIBLE_TYPE,               // @convBy!Proxy for ubyte[]
 ];
 
 static immutable string[] ColumnTypeDatasetReaderCode = 
@@ -695,28 +837,102 @@ static immutable string[] ColumnTypeDatasetReaderCode =
     "Nullable!TimeOfDay(r.getTime(index))", //NULLABLE_TIME_TYPE, // Nullable!std.datetime.TimeOfDay
     "r.getBytes(index)", //BYTE_ARRAY_TYPE, // byte[]
     "r.getUbytes(index)", //UBYTE_ARRAY_TYPE, // ubyte[]
+    
+    "r.getLong(index)", //LONG_CONVERTIBLE_TYPE,                      // @convBy!Proxy for long
+    "r.getUlong(index)", //ULONG_CONVERTIBLE_TYPE,                     // @convBy!Proxy for ulong
+    "Nullable!(r.getLong(index))", //NULLABLE_LONG_CONVERTIBLE_TYPE,             // @convBy!Proxy for Nullable!long
+    "Nullable!(r.getUlong(index))", //NULLABLE_ULONG_CONVERTIBLE_TYPE,            // @convBy!Proxy for Nullable!ulong
+    "r.getDouble(index)", //DOUBLE_CONVERTIBLE_TYPE,                    // @convBy!Proxy for double
+    "Nullable!(r.getDouble(index))", //NULLABLE_DOUBLE_CONVERTIBLE_TYPE,           // @convBy!Proxy for Nullable!double
+    "r.getString(index)", //STRING_CONVERTIBLE_TYPE,                    // @convBy!Proxy for string
+    "r.getString(index)", //NULLABLE_STRING_CONVERTIBLE_TYPE,           // @convBy!Proxy for String
+    "r.getBytes(index)", //BYTE_ARRAY_CONVERTIBLE_TYPE,                // @convBy!Proxy for byte[]
+    "r.getUbytes(index)", //UBYTE_ARRAY_CONVERTIBLE_TYPE,               // @convBy!Proxy for ubyte[]
 ];
+
+string getConvertibleTypeCode(T, string m)() if (hasConvBy!(__traits(getMember, T, m))) {
+    alias member = __traits(getMember, T, m);
+    static if (isConvertible!(member, long)) {
+        return "long";
+    } else static if (isConvertible!(member, ulong)) {
+        return "ulong";
+    } else static if (isConvertible!(member, Nullable!long)) {
+        return "Nullable!long";
+    } else static if (isConvertible!(member, Nullable!ulong)) {
+        return "Nullable!ulong";
+    } else static if (isConvertible!(member, double)) {
+        return "double";
+    } else static if (isConvertible!(member, Nullable!double)) {
+        return "Nullable!double";
+    } else static if (isConvertible!(member, string)) {
+        return "string";
+    } else static if (isConvertible!(member, String)) {
+        return "String";
+    } else static if (isConvertible!(member, byte[])) {
+        return "byte[]";
+    } else static if (isConvertible!(member, ubyte[])) {
+        return "ubyte[]";
+    } else static if (true) {
+        static assert (false, "Member " ~ m ~ " of class " ~ T.stringof ~ " has unsupported type " ~ typeof(member).stringof);
+    }
+}
+template getConvertibleType(alias value) if (hasConvBy!(value)) {
+    static if (isConvertible!(value, long)) {
+        alias getConvertibleType = long;
+    } else static if (isConvertible!(value, ulong)) {
+        alias getConvertibleType = ulong;
+    } else static if (isConvertible!(value, Nullable!long)) {
+        alias getConvertibleType = Nullable!long;
+    } else static if (isConvertible!(value, Nullable!ulong)) {
+        alias getConvertibleType = Nullable!ulong;
+    } else static if (isConvertible!(value, double)) {
+        alias getConvertibleType = double;
+    } else static if (isConvertible!(value, Nullable!double)) {
+        alias getConvertibleType = Nullable!double;
+    } else static if (isConvertible!(value, string)) {
+        alias getConvertibleType = string;
+    } else static if (isConvertible!(value, String)) {
+        alias getConvertibleType = String;
+    } else static if (isConvertible!(value, byte[])) {
+        alias getConvertibleType = byte[];
+    } else static if (isConvertible!(value, ubyte[])) {
+        alias getConvertibleType = ubyte[];
+    } else static if (true) {
+        static assert (false, "Member " ~ m ~ " of class " ~ T.stringof ~ " has unsupported type " ~ typeof(member).stringof);
+    }
+}
+
+alias getConvertibleType(T, string m)  = getConvertibleType!(__traits(getMember, T, m));
 
 string getColumnTypeDatasetReadCode(T, string m)() {
     return ColumnTypeDatasetReaderCode[getPropertyMemberType!(T,m)()];
 }
 
-string getVarTypeDatasetReadCode(T)() {
-    return ColumnTypeDatasetReaderCode[getPropertyType!T];
+string getVarTypeDatasetReadCode(alias arg)() {
+    return ColumnTypeDatasetReaderCode[getPropertyType!arg];
 }
 
 string getPropertyWriteCode(T, string m)() {
     //immutable PropertyMemberKind kind = getPropertyMemberKind!(T, m)();
     immutable string nullValueCode = ColumnTypeSetNullCode[getPropertyMemberType!(T,m)()];
     immutable string datasetReader = "(!r.isNull(index) ? " ~ getColumnTypeDatasetReadCode!(T, m)() ~ " : nv)";
-    return nullValueCode ~ "entity." ~ m ~ " = " ~ datasetReader ~ ";";
+    static if (hasConvBy!(__traits(getMember, T, m)) && canConvFrom!(__traits(getMember, T, m), getConvertibleType!(T, m))) {
+        return nullValueCode ~ "convertFrom!(entity." ~ m ~ ")("~ datasetReader ~ ", entity." ~ m ~ ");";
+    } else {
+        return nullValueCode ~ "entity." ~ m ~ " = " ~ datasetReader ~ ";";
+    }
 }
 
-string getPropertyWriteCode(T)() {
+string getArgsWriteCode(alias value)() {
+    alias T = typeof(value);
     //immutable PropertyMemberKind kind = getPropertyMemberKind!(T, m)();
-    immutable string nullValueCode = ColumnTypeSetNullCode[getPropertyType!T];
-    immutable string datasetReader = "(!r.isNull(index) ? " ~ getVarTypeDatasetReadCode!T ~ " : nv)";
-    return nullValueCode ~ "a = " ~ datasetReader ~ ";";
+    immutable string nullValueCode = ColumnTypeSetNullCode[getPropertyType!value];
+    immutable string datasetReader = "(!r.isNull(index) ? " ~ getVarTypeDatasetReadCode!value ~ " : nv)";
+    static if (hasConvBy!value && canConvFrom!(value, getConvertibleType!value)) {
+        return nullValueCode ~ "convertFrom!(a)(" ~ datasetReader ~ ", a);";
+    } else {
+        return nullValueCode ~ "a = " ~ datasetReader ~ ";";
+    }
 }
 
 /// returns array of field names
@@ -726,8 +942,12 @@ string[] getColumnNamesForType(T)()  if (__traits(isPOD, T)) {
         static if (__traits(compiles, (typeof(__traits(getMember, T, m))))){
             // skip non-public members
             static if (__traits(getProtection, __traits(getMember, T, m)) == "public") {
-                static if (isSupportedSimpleType!(T, m)) {
-                    res ~= m;
+                static if (isSupportedSimpleType!(T, m) && !hasIgnore!(__traits(getMember, T, m))) {
+                    static if (hasColumnName!(__traits(getMember, T, m))) {
+                        res ~= getColumnName!(__traits(getMember, T, m));
+                    } else {
+                        res ~= m;
+                    }
                 }
             }
         }
@@ -745,7 +965,7 @@ string getAllColumnsReadCode(T)() {
         static if (__traits(compiles, (typeof(__traits(getMember, T, m))))){
             // skip non-public members
             static if (__traits(getProtection, __traits(getMember, T, m)) == "public") {
-                static if (isSupportedSimpleType!(T, m)) {
+                static if (isSupportedSimpleType!(T, m) && !hasIgnore!(__traits(getMember, T, m))) {
                     res ~= getColumnReadCode!(T, m);
                 }
             }
@@ -768,21 +988,27 @@ unittest {
         string name;
         int flags;
     }
-    //pragma(msg, "nullValueCode = " ~ ColumnTypeSetNullCode[getPropertyMemberType!(User, "id")()]);
-    //pragma(msg, "datasetReader = " ~ getColumnTypeDatasetReadCode!(User, "id")());
-    //pragma(msg, "getPropertyWriteCode: " ~ getPropertyWriteCode!(User, "id"));
-    //pragma(msg, "getAllColumnsReadCode:\n" ~ getAllColumnsReadCode!(User));
-    //static assert(getPropertyWriteCode!(User, "id") == "long nv = 0;entity.id = (!r.isNull(index) ? r.getLong(index) : nv);");
+    //pragma(msg, "nullValueCode = " ~ ColumnTypeSetNullCode[getPropertyMemberType!(User1, "id")()]);
+    //pragma(msg, "datasetReader = " ~ getColumnTypeDatasetReadCode!(User1, "id")());
+    //pragma(msg, "getPropertyWriteCode: " ~ getPropertyWriteCode!(User1, "id"));
+    //pragma(msg, "getAllColumnsReadCode:\n" ~ getAllColumnsReadCode!(User1));
+    //static assert(getPropertyWriteCode!(User1, "id") == "long nv = 0;entity.id = (!r.isNull(index) ? r.getLong(index) : nv);");
 }
 
 unittest {
     struct User1 {
         long id;
         string name;
+        static struct Proxy {
+            string to(int x) { static import std.conv; return std.conv.to!string(x); }
+            int from(string x) { static import std.conv; return std.conv.to!int(x); }
+        }
+        @convBy!Proxy
         int flags;
     }
     static assert(getPropertyMemberType!(User1, "id")() == PropertyMemberType.LONG_TYPE);
     static assert(getPropertyMemberType!(User1, "name")() == PropertyMemberType.STRING_TYPE);
+    static assert(getPropertyMemberType!(User1, "flags")() == PropertyMemberType.STRING_CONVERTIBLE_TYPE);
     //pragma(msg, "getPropertyMemberType unit test passed");
 }
 
@@ -790,7 +1016,11 @@ unittest {
 
 /// returns table name for struct type
 string getTableNameForType(T)() if (__traits(isPOD, T)) {
-    return camelCaseToUnderscoreDelimited(T.stringof);
+    static if (hasTableName!T) {
+        return getTableName!T;
+    } else {
+        return camelCaseToUnderscoreDelimited(T.stringof);
+    }
 }
 
 unittest {
@@ -800,6 +1030,14 @@ unittest {
         int flags;
     }
     static assert(getTableNameForType!User1() == "user1");
+    
+    @tableName("user_2")
+    struct User2 {
+        long id;
+        string name;
+        int flags;
+    }
+    static assert(getTableNameForType!User2() == "user_2");
 }
 
 /// returns "SELECT <field list> FROM <table name>"
@@ -814,6 +1052,22 @@ unittest {
         int flags;
     }
     static assert(generateSelectSQL!User1() == "SELECT id,name,flags FROM user1");
+    
+    @tableName("user_2")
+    struct User2 {
+        long id;
+        
+        @columnName("name_of_user")
+        string name;
+        
+        static struct Proxy {
+            string to(int x) { static import std.conv; return std.conv.to!string(x); }
+            int from(string x) { static import std.conv; return std.conv.to!int(x); }
+        }
+        @convBy!Proxy
+        int flags;
+    }
+    static assert(generateSelectSQL!User2() == "SELECT id,name_of_user,flags FROM user_2");
 }
 
 string joinFieldList(fieldList...)() {
@@ -941,13 +1195,42 @@ string getColumnTypeDatasetReadCodeByName(T, string m)() {
             return `Nullable!SysTime(r.getSysTime("` ~ m ~ `"))`;
         case NULLABLE_DATETIME_TYPE:
             return `Nullable!DateTime(r.getDateTime("` ~ m ~ `"))`;
+    
+        case LONG_CONVERTIBLE_TYPE:
+            return `r.getLong("` ~ m ~ `")`;
+        case ULONG_CONVERTIBLE_TYPE:
+            return `r.getUlong("` ~ m ~ `")`;
+        case NULLABLE_LONG_CONVERTIBLE_TYPE:
+            return `Nullable!long(r.getLong("` ~ m ~ `"))`;
+        case NULLABLE_ULONG_CONVERTIBLE_TYPE:
+            return `Nullable!ulong(r.getUlong("` ~ m ~ `"))`;
+        case DOUBLE_CONVERTIBLE_TYPE:
+            return `r.getDouble("` ~ m ~ `")`;
+        case NULLABLE_DOUBLE_CONVERTIBLE_TYPE:
+            return `Nullable!double(r.getDouble("` ~ m ~ `"))`;
+        case STRING_CONVERTIBLE_TYPE:
+            return `r.getString("` ~ m ~ `")`;
+        case NULLABLE_STRING_CONVERTIBLE_TYPE:
+            return `r.getString("` ~ m ~ `")`;
+        case BYTE_ARRAY_CONVERTIBLE_TYPE:
+            return `r.getBytes("` ~ m ~ `")`;
+        case UBYTE_ARRAY_CONVERTIBLE_TYPE:
+            return `r.getUbytes("` ~ m ~ `")`;
     }
 }
 
 string getPropertyWriteCodeByName(T, string m)() {
     immutable string nullValueCode = ColumnTypeSetNullCode[getPropertyMemberType!(T,m)()];
-    immutable string propertyWriter = nullValueCode ~ "entity." ~ m ~ " = " ~ getColumnTypeDatasetReadCodeByName!(T, m)() ~ ";\n";
-    return propertyWriter ~ "if (r.wasNull) entity." ~ m ~ " = nv;";
+    alias value = __traits(getMember, T, m);
+    static if (hasConvBy!value && canConvFrom!(value, getConvertibleType!value)) {
+        immutable string propertyWriter = nullValueCode
+                ~ "convertFrom!(entity." ~ m ~ ", " ~ getConvertibleTypeCode!value ~ ")"
+                ~             "(" ~ getColumnTypeDatasetReadCodeByName!(T, m)() ~ ", entity." ~ m ~ ");\n";
+        return propertyWriter ~ "if (r.wasNull) entity." ~ m ~ " = nv;";
+    } else {
+        immutable string propertyWriter = nullValueCode ~ "entity." ~ m ~ " = " ~ getColumnTypeDatasetReadCodeByName!(T, m)() ~ ";\n";
+        return propertyWriter ~ "if (r.wasNull) entity." ~ m ~ " = nv;";
+    }
 }
 
 string getColumnReadCodeByName(T, string m)() {
@@ -960,7 +1243,7 @@ string getAllColumnsReadCodeByName(T)() {
         static if (__traits(compiles, (typeof(__traits(getMember, T, m))))){
             // skip non-public members
             static if (__traits(getProtection, __traits(getMember, T, m)) == "public") {
-                static if (isSupportedSimpleType!(T, m)) {
+                static if (isSupportedSimpleType!(T, m) && hasIgnore!(__traits(getMember, T, m))) {
                     res ~= getColumnReadCodeByName!(T, m);
                 }
             }
@@ -1152,73 +1435,73 @@ template isSupportedSimpleTypeRef(M) {
     static if (!__traits(isRef, M)) {
         enum bool isSupportedSimpleTypeRef = false;
     } else static if (is(ti == bool)) {
-        enum bool isSupportedSimpleType = true;
+        enum bool isSupportedSimpleTypeRef = true;
     } else static if (is(ti == byte)) {
-        enum bool isSupportedSimpleType = true;
+        enum bool isSupportedSimpleTypeRef = true;
     } else static if (is(ti == short)) {
-        enum bool isSupportedSimpleType = true;
+        enum bool isSupportedSimpleTypeRef = true;
     } else static if (is(ti == int)) {
-        enum bool isSupportedSimpleType = true;
+        enum bool isSupportedSimpleTypeRef = true;
     } else static if (is(ti == long)) {
-        enum bool isSupportedSimpleType = true;
+        enum bool isSupportedSimpleTypeRef = true;
     } else static if (is(ti == ubyte)) {
-        enum bool isSupportedSimpleType = true;
+        enum bool isSupportedSimpleTypeRef = true;
     } else static if (is(ti == ushort)) {
-        enum bool isSupportedSimpleType = true;
+        enum bool isSupportedSimpleTypeRef = true;
     } else static if (is(ti == uint)) {
-        enum bool isSupportedSimpleType = true;
+        enum bool isSupportedSimpleTypeRef = true;
     } else static if (is(ti == ulong)) {
-        enum bool isSupportedSimpleType = true;
+        enum bool isSupportedSimpleTypeRef = true;
     } else static if (is(ti == float)) {
-        enum bool isSupportedSimpleType = true;
+        enum bool isSupportedSimpleTypeRef = true;
     } else static if (is(ti == double)) {
-        enum bool isSupportedSimpleType = true;
+        enum bool isSupportedSimpleTypeRef = true;
     } else static if (is(ti == Nullable!byte)) {
-        enum bool isSupportedSimpleType = true;
+        enum bool isSupportedSimpleTypeRef = true;
     } else static if (is(ti == Nullable!short)) {
-        enum bool isSupportedSimpleType = true;
+        enum bool isSupportedSimpleTypeRef = true;
     } else static if (is(ti == Nullable!int)) {
-        enum bool isSupportedSimpleType = true;
+        enum bool isSupportedSimpleTypeRef = true;
     } else static if (is(ti == Nullable!long)) {
-        enum bool isSupportedSimpleType = true;
+        enum bool isSupportedSimpleTypeRef = true;
     } else static if (is(ti == Nullable!ubyte)) {
-        enum bool isSupportedSimpleType = true;
+        enum bool isSupportedSimpleTypeRef = true;
     } else static if (is(ti == Nullable!ushort)) {
-        enum bool isSupportedSimpleType = true;
+        enum bool isSupportedSimpleTypeRef = true;
     } else static if (is(ti == Nullable!uint)) {
-        enum bool isSupportedSimpleType = true;
+        enum bool isSupportedSimpleTypeRef = true;
     } else static if (is(ti == Nullable!ulong)) {
-        enum bool isSupportedSimpleType = true;
+        enum bool isSupportedSimpleTypeRef = true;
     } else static if (is(ti == Nullable!float)) {
-        enum bool isSupportedSimpleType = true;
+        enum bool isSupportedSimpleTypeRef = true;
     } else static if (is(ti == Nullable!double)) {
-        enum bool isSupportedSimpleType = true;
+        enum bool isSupportedSimpleTypeRef = true;
     } else static if (is(ti == string)) {
-        enum bool isSupportedSimpleType = true;
+        enum bool isSupportedSimpleTypeRef = true;
     } else static if (is(ti == String)) {
-        enum bool isSupportedSimpleType = true;
+        enum bool isSupportedSimpleTypeRef = true;
     } else static if (is(ti == SysTime)) {
-        enum bool isSupportedSimpleType = true;
+        enum bool isSupportedSimpleTypeRef = true;
     } else static if (is(ti == DateTime)) {
-        enum bool isSupportedSimpleType = true;
+        enum bool isSupportedSimpleTypeRef = true;
     } else static if (is(ti == Date)) {
-        enum bool isSupportedSimpleType = true;
+        enum bool isSupportedSimpleTypeRef = true;
     } else static if (is(ti == TimeOfDay)) {
-        enum bool isSupportedSimpleType = true;
+        enum bool isSupportedSimpleTypeRef = true;
     } else static if (is(ti == Nullable!SysTime)) {
-        enum bool isSupportedSimpleType = true;
+        enum bool isSupportedSimpleTypeRef = true;
     } else static if (is(ti == Nullable!DateTime)) {
-        enum bool isSupportedSimpleType = true;
+        enum bool isSupportedSimpleTypeRef = true;
     } else static if (is(ti == Nullable!Date)) {
-        enum bool isSupportedSimpleType = true;
+        enum bool isSupportedSimpleTypeRef = true;
     } else static if (is(ti == Nullable!TimeOfDay)) {
-        enum bool isSupportedSimpleType = true;
+        enum bool isSupportedSimpleTypeRef = true;
     } else static if (is(ti == byte[])) {
-        enum bool isSupportedSimpleType = true;
+        enum bool isSupportedSimpleTypeRef = true;
     } else static if (is(ti == ubyte[])) {
-        enum bool isSupportedSimpleType = true;
+        enum bool isSupportedSimpleTypeRef = true;
     } else static if (true) {
-        enum bool isSupportedSimpleType = false;
+        enum bool isSupportedSimpleTypeRef = false;
     }
 }
 
@@ -1250,10 +1533,10 @@ struct select(Args...)  {//if (isSupportedSimpleTypeRefList!Args())
         this.stmt = stmt;
         selectSQL = sql;
         _copyFunction = delegate() {
-            foreach(i, ref a; args) {
+            static foreach(i, a; args) {{
                 int index = i + 1;
-                mixin(getPropertyWriteCode!(typeof(a)));
-            }
+                mixin(getArgsWriteCode!a);
+            }}
         };
     }
 

--- a/source/ddbc/pods.d
+++ b/source/ddbc/pods.d
@@ -446,7 +446,7 @@ PropertyMemberType getPropertyType(alias value)() {
 
 PropertyMemberType getPropertyMemberType(T, string m)() {
     alias typeof(__traits(getMember, T, m)) ti;
-    alias member = __traits(getMember, T, m);
+    mixin(`alias member = T.` ~ m ~ ";"); // alias member = __traits(getMember, T, m);
     static if (hasConvBy!member) {
         static if (isConvertible!(member, long)) {
             return PropertyMemberType.LONG_CONVERTIBLE_TYPE;
@@ -851,7 +851,7 @@ static immutable string[] ColumnTypeDatasetReaderCode =
 ];
 
 string getConvertibleTypeCode(T, string m)() if (hasConvBy!(__traits(getMember, T, m))) {
-    alias member = __traits(getMember, T, m);
+    mixin(`alias member = T.` ~ m ~ ";"); // alias member = __traits(getMember, T, m);
     static if (isConvertible!(member, long)) {
         return "long";
     } else static if (isConvertible!(member, ulong)) {
@@ -1221,7 +1221,7 @@ string getColumnTypeDatasetReadCodeByName(T, string m)() {
 
 string getPropertyWriteCodeByName(T, string m)() {
     immutable string nullValueCode = ColumnTypeSetNullCode[getPropertyMemberType!(T,m)()];
-    alias value = __traits(getMember, T, m);
+    mixin(`alias value = T.` ~ m ~ ";"); // alias value = __traits(getMember, T, m);
     static if (hasConvBy!value && canConvFrom!(value, getConvertibleType!value)) {
         immutable string propertyWriter = nullValueCode
                 ~ "convertFrom!(entity." ~ m ~ ", " ~ getConvertibleTypeCode!value ~ ")"
@@ -1709,7 +1709,6 @@ version (unittest) {
 }
 
 unittest {
-    import std;
     auto stmt = new StubStatement;
     scope (exit) stmt.close();
     struct Data {


### PR DESCRIPTION
The ddbc.pods are very friendly to UDA. So I let the UDA be applied to `select`.

As an addendum, I thought about refactoring the part of the commit that was too cluttered following this one and making UDA support for insert/update/remove as well. However, the commit was huge enough by the time I got it to support select, so I decided to split it up. If this pull request is accepted, I'll post the rest of the split in order.

After all the changes are made, it looks like this:
https://github.com/shoo/ddbc/blob/c25eb0f034d6a6a03c1f1050d7fdd84677c0ab1d/source/ddbc/pods.d