### PR TITLE
Fixes #112: Migrate to std.logger (no longer experimental since DMD 2.101.0)

### DIFF
--- a/example/source/testddbc.d
+++ b/example/source/testddbc.d
@@ -86,7 +86,12 @@ struct ConnectionParams
 }
 int main(string[] args)
 {
-	import std.logger;
+	static if (__traits(compiles, (){ import std.logger; } )) {
+		import std.logger;
+	} else {
+		import std.experimental.logger;
+	}
+
 	globalLogLevel(LogLevel.all);
 
 	ConnectionParams par;

--- a/example/source/testddbc.d
+++ b/example/source/testddbc.d
@@ -86,10 +86,8 @@ struct ConnectionParams
 }
 int main(string[] args)
 {
-	static if(__traits(compiles, (){ import std.experimental.logger; } )) {
-		import std.experimental.logger;
-		globalLogLevel(LogLevel.all);
-	}
+	import std.logger;
+	globalLogLevel(LogLevel.all);
 
 	ConnectionParams par;
 	string URI;

--- a/source/ddbc/common.d
+++ b/source/ddbc/common.d
@@ -24,7 +24,12 @@ module ddbc.common;
 import ddbc.core;
 import std.algorithm;
 import std.exception;
-import std.logger;
+static if (__traits(compiles, (){ import std.logger; } )) {
+    import std.logger;
+} else {
+    import std.experimental.logger;
+}
+
 import std.stdio;
 import std.conv;
 import std.variant;

--- a/source/ddbc/common.d
+++ b/source/ddbc/common.d
@@ -24,10 +24,7 @@ module ddbc.common;
 import ddbc.core;
 import std.algorithm;
 import std.exception;
-static if(__traits(compiles, (){ import std.experimental.logger; } )) {
-    import std.experimental.logger;
-    pragma(msg, "DDBC will log using 'std.experimental.logger'.");
-}
+import std.logger;
 import std.stdio;
 import std.conv;
 import std.variant;
@@ -162,9 +159,7 @@ public:
 		Connection conn = null;
         //writeln("getConnection(): freeConnections.length = " ~ to!string(freeConnections.length));
         if (freeConnections.length > 0) {
-			static if(__traits(compiles, (){ import std.experimental.logger; } )) {
-				sharedLog.tracef("Retrieving database connection from pool of %s", freeConnections.length);
-			}
+    				tracef("Retrieving database connection from pool of %s", freeConnections.length);
             conn = freeConnections[freeConnections.length - 1]; // $ - 1
             auto oldSize = freeConnections.length;
             myRemove(freeConnections, freeConnections.length - 1);
@@ -172,14 +167,12 @@ public:
             auto newSize = freeConnections.length;
             assert(newSize == oldSize - 1);
         } else {
-            sharedLog.tracef("Creating new database connection (%s) %s %s", driver, url, params);
+            tracef("Creating new database connection (%s) %s %s", driver, url, params);
 
             try {
                 conn = super.getConnection();
             } catch (Throwable e) {
-				static if(__traits(compiles, (){ import std.experimental.logger; } )) {
-					sharedLog.errorf("could not create db connection : %s", e.msg);
-				}
+                errorf("could not create db connection : %s", e.msg);
                 throw e;
             }
             //writeln("getConnection(): connection created");
@@ -201,9 +194,7 @@ public:
                 //activeConnections.length = oldSize - 1;
                 auto newSize = activeConnections.length;
                 assert(oldSize == newSize + 1);
-				static if(__traits(compiles, (){ import std.experimental.logger; } )) {
-					sharedLog.tracef("database connections reduced from %s to %s", oldSize, newSize);
-				}
+                tracef("database connections reduced from %s to %s", oldSize, newSize);
                 return;
 			}
 		}

--- a/source/ddbc/drivers/mysqlddbc.d
+++ b/source/ddbc/drivers/mysqlddbc.d
@@ -30,10 +30,7 @@ import std.datetime : Date, DateTime, TimeOfDay;
 import std.datetime.date;
 import std.datetime.systime;
 import std.exception : enforce;
-
-static if(__traits(compiles, (){ import std.experimental.logger; } )) {
-    import std.experimental.logger;
-}
+import std.logger;
 import std.stdio;
 import std.string;
 import std.variant;
@@ -361,9 +358,7 @@ public:
         lock();
         scope(exit) unlock();
 
-        static if(__traits(compiles, (){ import std.experimental.logger; } )) {
-            sharedLog.trace(queryString);
-        }
+        trace(queryString);
 
 		try {
 	        results = query(conn.getConnection(), queryString);
@@ -379,9 +374,7 @@ public:
         scope(exit) unlock();
 		ulong rowsAffected = 0;
 
-        static if(__traits(compiles, (){ import std.experimental.logger; } )) {
-            sharedLog.trace(query);
-        }
+        trace(query);
         
 		try {
 			rowsAffected = exec(conn.getConnection(), query);
@@ -511,9 +504,7 @@ public:
         lock();
         scope(exit) unlock();
 
-        static if(__traits(compiles, (){ import std.experimental.logger; } )) {
-            sharedLog.trace(statement.sql());
-        }
+            trace(statement.sql());
 
         try {
             results = query(conn.getConnection(), statement);

--- a/source/ddbc/drivers/mysqlddbc.d
+++ b/source/ddbc/drivers/mysqlddbc.d
@@ -30,7 +30,12 @@ import std.datetime : Date, DateTime, TimeOfDay;
 import std.datetime.date;
 import std.datetime.systime;
 import std.exception : enforce;
-import std.logger;
+static if (__traits(compiles, (){ import std.logger; } )) {
+    import std.logger;
+} else {
+    import std.experimental.logger;
+}
+
 import std.stdio;
 import std.string;
 import std.variant;

--- a/source/ddbc/drivers/odbcddbc.d
+++ b/source/ddbc/drivers/odbcddbc.d
@@ -27,10 +27,7 @@ import std.datetime : Date, DateTime, TimeOfDay;
 import std.datetime.date;
 import std.datetime.systime;
 import std.exception : enforce;
-
-static if(__traits(compiles, (){ import std.experimental.logger; } )) {
-    import std.experimental.logger;
-}
+import std.logger;
 import std.stdio;
 import std.string;
 import std.variant;
@@ -105,9 +102,9 @@ version (USE_ODBC)
         debug
         {
             if(retval < 0) {
-                sharedLog.errorf("%s(%s) : %s", fullyQualifiedName!fn, format("%(%s%|, %)", tuple(args)), cast(RetVals) retval);
+                errorf("%s(%s) : %s", fullyQualifiedName!fn, format("%(%s%|, %)", tuple(args)), cast(RetVals) retval);
             } else {
-                //sharedLog.tracef("%s(%s) : %s", fullyQualifiedName!fn, format("%(%s%|, %)", tuple(args)), cast(RetVals) retval);
+                //tracef("%s(%s) : %s", fullyQualifiedName!fn, format("%(%s%|, %)", tuple(args)), cast(RetVals) retval);
             }
         }
 
@@ -423,7 +420,7 @@ version (USE_ODBC)
             addToConnectionString("trusted_connection", "TrustServerCertificate");
             string connectionString = connectionProps.join(';');
             
-            sharedLog.info(connectionString);
+            info(connectionString);
 
             SQLCHAR[1024] outstr;
             SQLSMALLINT outstrlen;
@@ -622,9 +619,7 @@ version (USE_ODBC)
             scope (exit)
                 unlock();
             
-            static if(__traits(compiles, (){ import std.experimental.logger; } )) {
-                sharedLog.trace(query);
-            }
+            trace(query);
 
             try
             {
@@ -657,9 +652,7 @@ version (USE_ODBC)
                 unlock();
             int rowsAffected = 0;
 
-            static if(__traits(compiles, (){ import std.experimental.logger; } )) {
-                sharedLog.trace(query);
-            }
+            trace(query);
 
             try
             {
@@ -682,9 +675,7 @@ version (USE_ODBC)
             scope (exit)
                 unlock();
             
-            static if(__traits(compiles, (){ import std.experimental.logger; } )) {
-                sharedLog.trace(query);
-            }
+            trace(query);
 
             try
             {
@@ -1011,9 +1002,7 @@ version (USE_ODBC)
             scope (exit)
                 unlock();
             
-            static if(__traits(compiles, (){ import std.experimental.logger; } )) {
-                sharedLog.trace(stmt);
-            }
+            trace(stmt);
 
             try
             {
@@ -1037,9 +1026,7 @@ version (USE_ODBC)
             scope (exit)
                 unlock();
             
-            static if(__traits(compiles, (){ import std.experimental.logger; } )) {
-                sharedLog.trace(stmt);
-            }
+            trace(stmt);
 
             try
             {
@@ -1069,9 +1056,7 @@ version (USE_ODBC)
             scope (exit)
                 unlock();
 
-            static if(__traits(compiles, (){ import std.experimental.logger; } )) {
-                sharedLog.trace(stmt);
-            }
+            trace(stmt);
 
             try
             {
@@ -1340,7 +1325,7 @@ version (USE_ODBC)
                 items[i].typeName = (cast(SqlType) items[i].type).to!(string);
                 items[i].isNullable = col.nullAble == SQL_NULLABLE;
 
-                debug sharedLog.tracef("Column meta data: catalogName='%s', name='%s', typeName='%s'", items[i].catalogName, items[i].name, items[i].typeName);
+                debug tracef("Column meta data: catalogName='%s', name='%s', typeName='%s'", items[i].catalogName, items[i].name, items[i].typeName);
             }
 
             metadata = new ResultSetMetaDataImpl(items);

--- a/source/ddbc/drivers/odbcddbc.d
+++ b/source/ddbc/drivers/odbcddbc.d
@@ -27,7 +27,12 @@ import std.datetime : Date, DateTime, TimeOfDay;
 import std.datetime.date;
 import std.datetime.systime;
 import std.exception : enforce;
-import std.logger;
+static if (__traits(compiles, (){ import std.logger; } )) {
+    import std.logger;
+} else {
+    import std.experimental.logger;
+}
+
 import std.stdio;
 import std.string;
 import std.variant;

--- a/source/ddbc/drivers/pgsqlddbc.d
+++ b/source/ddbc/drivers/pgsqlddbc.d
@@ -32,10 +32,7 @@ version(USE_PGSQL) {
     import std.datetime.date;
     import std.datetime.systime;
     import std.exception : enforce;
-
-    static if(__traits(compiles, (){ import std.experimental.logger; } )) {
-        import std.experimental.logger;
-    }
+    import std.logger;
     import std.stdio;
     import std.string;
     import std.variant;
@@ -578,9 +575,8 @@ version(USE_PGSQL) {
     		lock();
     		scope(exit) unlock();
 
-            static if(__traits(compiles, (){ import std.experimental.logger; } )) {
-                sharedLog.trace(query);
-            }
+            trace(query);
+
     		PGresult * res = PQexec(conn.getConnection(), std.string.toStringz(query));
     		enforce!SQLException(res !is null, "Failed to execute statement " ~ query);
     		auto status = PQresultStatus(res);
@@ -624,9 +620,7 @@ version(USE_PGSQL) {
     		lock();
     		scope(exit) unlock();
 
-            static if(__traits(compiles, (){ import std.experimental.logger; } )) {
-                sharedLog.trace(query);
-            }
+            trace(query);
 
     		PGresult * res = PQexec(conn.getConnection(), std.string.toStringz(query));
     		enforce!SQLException(res !is null, "Failed to execute statement " ~ query);
@@ -835,9 +829,7 @@ version(USE_PGSQL) {
     		lock();
     		scope(exit) unlock();
 
-            static if(__traits(compiles, (){ import std.experimental.logger; } )) {
-                sharedLog.trace(this.query);
-            }
+            trace(this.query);
 
             PGresult * res = exec();
             scope(exit) PQclear(res);

--- a/source/ddbc/drivers/pgsqlddbc.d
+++ b/source/ddbc/drivers/pgsqlddbc.d
@@ -32,7 +32,11 @@ version(USE_PGSQL) {
     import std.datetime.date;
     import std.datetime.systime;
     import std.exception : enforce;
-    import std.logger;
+    static if (__traits(compiles, (){ import std.logger; } )) {
+        import std.logger;
+    } else {
+        import std.experimental.logger;
+    }
     import std.stdio;
     import std.string;
     import std.variant;

--- a/source/ddbc/drivers/sqliteddbc.d
+++ b/source/ddbc/drivers/sqliteddbc.d
@@ -31,7 +31,12 @@ version(USE_SQLITE) {
     import std.datetime.systime : SysTime, Clock;
     import std.datetime.timezone : UTC;
     import std.exception : enforce;
-    import std.logger;
+    static if (__traits(compiles, (){ import std.logger; } )) {
+        import std.logger;
+    } else {
+        import std.experimental.logger;
+    }
+
     import std.stdio;
     import std.string;
     import std.variant;

--- a/source/ddbc/drivers/sqliteddbc.d
+++ b/source/ddbc/drivers/sqliteddbc.d
@@ -31,10 +31,7 @@ version(USE_SQLITE) {
     import std.datetime.systime : SysTime, Clock;
     import std.datetime.timezone : UTC;
     import std.exception : enforce;
-
-    static if(__traits(compiles, (){ import std.experimental.logger; } )) {
-        import std.experimental.logger;
-    }
+    import std.logger;
     import std.stdio;
     import std.string;
     import std.variant;
@@ -171,10 +168,8 @@ version(USE_SQLITE) {
                     // YYYY-MM-DD HH:MM:SS.SSS
                     // YYYY-MM-DDTHH:MM:SS
                     // YYYY-MM-DDTHH:MM:SS.SSS
-                    static if(__traits(compiles, (){ import std.experimental.logger; } )) {
-                        if(sqliteString.length > 19) {
-                            sharedLog.warning(sqliteString ~ " will be converted to DateTime and lose the milliseconds. Consider using SysTime");
-                        }
+                    if(sqliteString.length > 19) {
+                        warning(sqliteString ~ " will be converted to DateTime and lose the milliseconds. Consider using SysTime");
                     }
 
                     auto date = Date.fromISOExtString(sqliteString[0..10]);
@@ -442,9 +437,7 @@ version(USE_SQLITE) {
         override ddbc.core.ResultSet executeQuery(string query) {
             closePreparedStatement();
             _currentStatement = conn.prepareStatement(query);
-            static if(__traits(compiles, (){ import std.experimental.logger; } )) {
-                sharedLog.trace(_currentStatement);
-            }
+            trace(_currentStatement);
             _currentResultSet = _currentStatement.executeQuery();
             return _currentResultSet;
         }
@@ -462,9 +455,7 @@ version(USE_SQLITE) {
             closePreparedStatement();
             _currentStatement = conn.prepareStatement(query);
 
-            static if(__traits(compiles, (){ import std.experimental.logger; } )) {
-                sharedLog.trace(_currentStatement);
-            }
+            trace(_currentStatement);
 
             return _currentStatement.executeUpdate(insertId);
         }

--- a/source/ddbc/drivers/utils.d
+++ b/source/ddbc/drivers/utils.d
@@ -58,10 +58,7 @@ SysTime parseSysTime(const string timestampString) @safe {
             return SysTime(parseDateTime(timestampString), UTC());
         }
     } catch (ConvException e) {
-        // static if(__traits(compiles, (){ import std.experimental.logger; } )) {
-        //     import std.experimental.logger : sharedLog; 
-        //     sharedLog.error("Could not parse " ~ timestampString ~ " to SysTime", e);
-        // }
+        // error("Could not parse " ~ timestampString ~ " to SysTime", e);
         throw new DateTimeException("Can not convert '" ~ timestampString ~ "' to SysTime");
     }
 }
@@ -103,10 +100,7 @@ DateTime parseDateTime(const string timestampString) @safe {
         }
         throw new DateTimeException("Can not convert " ~ timestampString);
     } catch (ConvException e) {
-        // static if(__traits(compiles, (){ import std.experimental.logger; } )) {
-        //     import std.experimental.logger : sharedLog;
-        //     sharedLog.error("Could not parse " ~ timestampString ~ " to SysTime", e);
-        // }
+        // error("Could not parse " ~ timestampString ~ " to SysTime", e);
         throw new DateTimeException("Can not convert '" ~ timestampString ~ "' to DateTime");
     }
 }

--- a/source/ddbc/pods.d
+++ b/source/ddbc/pods.d
@@ -1075,29 +1075,14 @@ bool insert(T)(Statement stmt, ref T o) if (__traits(isPOD, T)) {
     // https://issues.dlang.org/show_bug.cgi?id=18780
     // https://github.com/dlang/phobos/pull/7954
     if(insertId.convertsTo!(typeof(o.id))) {
-        static if(__traits(compiles, (){ import std.experimental.logger; } )) {
-            import std.experimental.logger ; sharedLog;
-            sharedLog.tracef("The ID is of type '%s' and can be a '%s'", insertId.type().toString(), typeof(o.id).stringof);
-        }
+        tracef("The ID is of type '%s' and can be a '%s'", insertId.type().toString(), typeof(o.id).stringof);
         o.id = insertId.get!(typeof(o.id)); // potentially could use coerce instead of get
     } else if(is(typeof(o.id) == uint) || is(typeof(o.id) == int)) {
         // This isn't generally an issue but on Windows (x86) using a size_t will result in a uint
-        static if(__traits(compiles, (){ import std.experimental.logger; } )) {
-            import std.experimental.logger ; sharedLog;
-            sharedLog.warningf("The ID is of type '%s', converting to type '%s' could cause data errors", insertId.type().toString(), typeof(o.id).stringof);
-        } else {
-            import std.stdio : writeln;
-            writeln("The ID is of type '" ~ insertId.type().toString() ~ "', converting to type '" ~ typeof(o.id).stringof ~ "' could cause data errors");
-        }
+        warningf("The ID is of type '%s', converting to type '%s' could cause data errors", insertId.type().toString(), typeof(o.id).stringof);
         o.id = to!(typeof(o.id))(insertId.get!ulong);  //  alternative syntax:   o.id = cast(typeof(o.id))insertId.get!ulong;
     } else {
-        static if(__traits(compiles, (){ import std.experimental.logger; } )) {
-            import std.experimental.logger ; sharedLog;
-            sharedLog.errorf("The ID is of type '%s' and cannot be converted to type '%s'", insertId.type().toString(), typeof(o.id).stringof);
-        } else {
-            import std.stdio : writeln;
-            writeln("The ID is of type '" ~ insertId.type().toString() ~ "' and cannot be converted to type: " ~ typeof(o.id).stringof);
-        }
+        errorf("The ID is of type '%s' and cannot be converted to type '%s'", insertId.type().toString(), typeof(o.id).stringof);
     }
 
     return true;

--- a/source/ddbc/pods.d
+++ b/source/ddbc/pods.d
@@ -55,6 +55,11 @@ import std.conv;
 import std.datetime;
 import std.string;
 import std.variant;
+static if (__traits(compiles, () { import std.logger; } )) {
+  import std.logger;
+} else {
+  import std.experimental.logger;
+}
 
 static import std.ascii;
 

--- a/test/ddbctest/common.d
+++ b/test/ddbctest/common.d
@@ -21,15 +21,13 @@ class DdbcTestFixture {
         this.setupSql = setupSql;
         this.teardownSql = teardownSql;
 
-        static if(__traits(compiles, (){ import std.experimental.logger; } )) {
-            import std.experimental.logger : globalLogLevel, sharedLog, LogLevel;
-            import std.experimental.logger.core : StdForwardLogger;
-            //pragma(msg, "Setting 'std.experimental.logger : sharedLog' to use 'stdout' logging...");
-            globalLogLevel(LogLevel.all);
-            //import std.experimental.logger.filelogger : FileLogger;
-            //sharedLog = new FileLogger(stdout);
-            //sharedLog = new StdForwardLogger(LogLevel.all);
-        }
+        import std.logger : globalLogLevel, sharedLog, LogLevel;
+        import std.logger.core : StdForwardLogger;
+        //pragma(msg, "Setting 'std.logger : sharedLog' to use 'stdout' logging...");
+        globalLogLevel(LogLevel.all);
+        //import std.logger.filelogger : FileLogger;
+        //sharedLog = new FileLogger(stdout);
+        //sharedLog = new StdForwardLogger(LogLevel.all);
     }
 
     @BeforeEach

--- a/test/ddbctest/common.d
+++ b/test/ddbctest/common.d
@@ -21,8 +21,14 @@ class DdbcTestFixture {
         this.setupSql = setupSql;
         this.teardownSql = teardownSql;
 
-        import std.logger : globalLogLevel, sharedLog, LogLevel;
-        import std.logger.core : StdForwardLogger;
+        static if (__traits(compiles, (){ import std.logger; } )) {
+            import std.logger : globalLogLevel, sharedLog, LogLevel;
+            import std.logger.core : StdForwardLogger;
+        } else {
+            import std.experimental.logger : globalLogLevel, sharedLog, LogLevel;
+            import std.experimental.logger.core : StdForwardLogger;
+        }
+
         //pragma(msg, "Setting 'std.logger : sharedLog' to use 'stdout' logging...");
         globalLogLevel(LogLevel.all);
         //import std.logger.filelogger : FileLogger;

--- a/test/ddbctest/main.d
+++ b/test/ddbctest/main.d
@@ -13,6 +13,8 @@ import ddbc.test.common : DdbcTestFixture;
 import ddbc.core : Connection, PreparedStatement, Statement, SQLException;
 import ddbc.pods;
 
+static import ddbc.core;
+
 version(USE_MYSQL) {
     pragma(msg, "DDBC test will run MySQL tests");
 


### PR DESCRIPTION
- Removed explicit references to `sharedLogger`, which are now explicitly of `shared` type. Replaced with calls to base function, e.g. `warnf`, which routes to the default logger.  See https://dlang.org/changelog/2.101.0.html#logger_sharedLog_returning_shared_logger
- Replaced imports of `std.experimental.logger` with `std.logger`, because `std.experimental.logger` has been deprecated since DMD 2.101.0.