### PR TITLE
Implement SQLITEResultSet.first()

### DIFF
--- a/test/ddbctest/main.d
+++ b/test/ddbctest/main.d
@@ -71,6 +71,28 @@ class SQLiteTest : DdbcTestFixture {
         // assertEquals("long", to!string(id.type));
         // assertEquals(2L, id.get!(long));
     }
+
+    @Test
+    public void testResultSetForEach() {
+        Statement stmt = conn.createStatement();
+        scope(exit) stmt.close();
+
+        stmt.executeUpdate(`INSERT INTO my_first_test (name) VALUES ('Goober')`);
+        stmt.executeUpdate(`INSERT INTO my_first_test (name) VALUES ('Goober')`);
+
+        PreparedStatement ps = conn.prepareStatement(`SELECT * FROM my_first_test WHERE name = ?`);
+        scope(exit) ps.close();
+
+        ps.setString(1, "Goober");
+
+        ddbc.core.ResultSet resultSet = ps.executeQuery();
+
+        int count = 0;
+        foreach (result; resultSet) {
+            count++;
+        }
+        assert(count == 2);
+    }
 }
 
 


### PR DESCRIPTION
If one attempts to run the following, a "not implemeneted" exception will be thrown:
```
auto statement = Connection.preparedStatement("Any SQL");
foreach (result; statement.executeQuery()) {
  ...
}
```

To avoid this, the unimplemented method "first()", which makes sure that the ResultSet is pointing at the first row, needs to be implemented. This is needed because `foreach` invokes `ResultSetImpl.opApply()`, which in turn invokes `first()`.