### PR TITLE
Process type BPCHAR the same way that text is processed.

### DIFF
--- a/source/ddbc/drivers/pgsqlddbc.d
+++ b/source/ddbc/drivers/pgsqlddbc.d
@@ -615,6 +615,7 @@ version(USE_PGSQL) {
                                     v[col] = parse!double(s);
                                     break;
                                 case VARCHAROID:
+                                case BPCHAROID:
                                 case TEXTOID:
                                 case NAMEOID:
                                     v[col] = s;


### PR DESCRIPTION
Just a one-liner that processes BPCHAR, a PostgreSQL-specific text type, the same way that text is treated.

Fixes: #130.