### PR TITLE
Fix fetch() on empty data

### DIFF
--- a/source/ddbc/drivers/odbcddbc.d
+++ b/source/ddbc/drivers/odbcddbc.d
@@ -826,18 +826,29 @@ version (USE_ODBC)
 
         bool fetch()
         {
-            bool hasData = checkstmt!SQLFetch(stmt) != SQL_NO_DATA;
-
-            if (hasData)
+            // Check if there is any data before calling SQLFetch
+            if(cols.length > 0)
             {
-                this.cols.each!(c => c.read());
+                bool hasData = checkstmt!SQLFetch(stmt) != SQL_NO_DATA;
+
+                if (hasData)
+                {
+                    this.cols.each!(c => c.read());
+                }
+                else
+                {
+                    SQLFreeStmt(stmt, SQL_CLOSE);
+                }
+
+                return hasData;
             }
             else
             {
+                // Error: No data
                 SQLFreeStmt(stmt, SQL_CLOSE);
+                stmt = null;
+                return false;
             }
-
-            return hasData;
         }
 
         class ColumnInfo


### PR DESCRIPTION
When trying to interact with a Microsoft SQL Server, the program brings the error "SQL ERROR" and reports "Invalid cursor state".

This is caused by calling SQLFetch() on empty data. This fix first checks if any columns exist before calling fetch.